### PR TITLE
Prevent bad packet id exception.

### DIFF
--- a/src/net/minecraft/server/Packet.java
+++ b/src/net/minecraft/server/Packet.java
@@ -94,7 +94,9 @@ public abstract class Packet {
             }
 
             if (flag && !serverPacketIdList.contains(Integer.valueOf(i)) || !flag && !clientPacketIdList.contains(Integer.valueOf(i))) {
-                throw new IOException("Bad packet id " + i);
+                System.out.println("Bad packet id: " + i); //Project Poseidon
+                return null; //Project Poseidon
+                //throw new IOException("Bad packet id " + i); //Project Poseidon - Comment Out
             }
 
             packet = a(i);


### PR DESCRIPTION
Modern clients, primarily the server list can lead to the server throwing a bad packet exception.