### PR TITLE
Add Player Connection initialization event

### DIFF
--- a/src/com/projectposeidon/johnymuffin/LoginProcessHandler.java
+++ b/src/com/projectposeidon/johnymuffin/LoginProcessHandler.java
@@ -1,12 +1,12 @@
 package com.projectposeidon.johnymuffin;
 
-import com.projectposeidon.api.PoseidonUUID;
 import net.minecraft.server.NetLoginHandler;
 import net.minecraft.server.Packet1Login;
 import net.minecraft.server.ThreadLoginVerifier;
 import org.bukkit.ChatColor;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerConnectionInitializationEvent;
 import org.bukkit.event.player.PlayerPreLoginEvent;
 import org.bukkit.plugin.Plugin;
 
@@ -55,6 +55,12 @@ public class LoginProcessHandler {
     }
 
     private void processAuthentication() {
+        PlayerConnectionInitializationEvent event = new PlayerConnectionInitializationEvent(this.packet1Login.name, this.netLoginHandler.getSocket().getInetAddress(), loginProcessHandler);
+        this.server.getPluginManager().callEvent(event);
+        if (loginCancelled) {
+            return;
+        }
+
         if (onlineMode) {
             //Server is running online mode
             verifyMojangSession();
@@ -148,7 +154,7 @@ public class LoginProcessHandler {
      * Set a pause for your plugin
      * Connection pauses are for fetching data for a player before they MIGHT be allowed to join
      *
-     * @param plugin Instance of plugin
+     * @param plugin              Instance of plugin
      * @param connectionPauseName Name of connection pause (Ensure no duplicates)
      * @return ConnectionPause Object, used to remove a connection pause
      */

--- a/src/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/org/bukkit/craftbukkit/CraftServer.java
@@ -71,7 +71,7 @@ public final class CraftServer implements Server {
         this.console = console;
         this.server = server;
         //this.serverVersion = CraftServer.class.getPackage().getImplementationVersion(); //Poseidon Replace
-        this.serverVersion = "1.0.8";
+        this.serverVersion = "1.1.3";
 
         Bukkit.setServer(this);
 

--- a/src/org/bukkit/event/Event.java
+++ b/src/org/bukkit/event/Event.java
@@ -149,7 +149,16 @@ public abstract class Event implements Serializable {
          */
         
         PACKET_RECEIVED (Category.PACKET),
-        
+
+
+        /**
+         * Called when a player first starts their connection. Called before UUID is known.
+         *
+         * @see org.bukkit.event.player.PlayerConnectionInitializationEvent
+         */
+        Player_Connection_Initialization(Category.PLAYER),
+
+
         /**
          * PLAYER EVENTS
          */

--- a/src/org/bukkit/event/player/PlayerConnectionInitializationEvent.java
+++ b/src/org/bukkit/event/player/PlayerConnectionInitializationEvent.java
@@ -1,0 +1,44 @@
+package org.bukkit.event.player;
+
+import com.projectposeidon.johnymuffin.LoginProcessHandler;
+import org.bukkit.event.Event;
+
+import java.net.InetAddress;
+
+public class PlayerConnectionInitializationEvent extends Event {
+    private String username;
+    private InetAddress ipAddress;
+    private LoginProcessHandler loginProcessHandler;
+    private boolean connecting = true;
+
+
+    public PlayerConnectionInitializationEvent(String username, InetAddress ipAddress, LoginProcessHandler loginProcessHandler) {
+        super(Type.Player_Connection_Initialization);
+        this.username = username;
+        this.ipAddress = ipAddress;
+        this.loginProcessHandler = loginProcessHandler;
+    }
+
+    public void disconnectPlayer(String kickReason) {
+        loginProcessHandler.cancelLoginProcess(kickReason);
+    }
+
+    /**
+     * Gets the player's name.
+     *
+     * @return the player's name
+     */
+    public String getName() {
+        return username;
+    }
+
+    /**
+     * Gets the player IP address.
+     *
+     * @return
+     */
+    public InetAddress getAddress() {
+        return ipAddress;
+    }
+
+}

--- a/version.json
+++ b/version.json
@@ -1,3 +1,3 @@
 {
-  "newestVersion": "1.1.0"
+  "newestVersion": "1.1.3"
 }


### PR DESCRIPTION
The event can be used in assisting to prevent bot attacks or preventing UUID lookups for set players.