### PR TITLE
Fix skeleton bow sound

### DIFF
--- a/src/net/minecraft/server/EntitySkeleton.java
+++ b/src/net/minecraft/server/EntitySkeleton.java
@@ -57,7 +57,7 @@ public class EntitySkeleton extends EntityMonster {
                 double d2 = entity.locY + (double) entity.t() - 0.20000000298023224D - entityarrow.locY;
                 float f1 = MathHelper.a(d0 * d0 + d1 * d1) * 0.2F;
 
-                this.world.makeSound(this, "random.bow", 1.0F, 1.0F / (this.random.nextFloat() * 0.4F + 0.8F));
+                this.world.e(1002, MathHelper.floor(this.locX), MathHelper.floor(this.locY - (double)this.height), MathHelper.floor(this.locZ), 0); // Poseidon - fix skeleton bow sounds (Strultz)
                 entityarrow.a(d0, d2 + (double) f1, d1, 0.6F, 12.0F);
                 this.world.addEntity(entityarrow);
                 this.attackTicks = 30;


### PR DESCRIPTION
Fixes skeleton bow sound not playing on clients. This uses some bow sound code for dispensers.

The only issue is that the sound pitch is static, instead of random

[Demo](https://user-images.githubusercontent.com/69481716/154605664-5733c0ba-e3ab-4d5c-98ea-6c4069a4a83c.mp4)


