### PR TITLE
Slime split fix.

### DIFF
--- a/src/net/minecraft/server/EntitySlime.java
+++ b/src/net/minecraft/server/EntitySlime.java
@@ -102,7 +102,7 @@ public class EntitySlime extends EntityLiving implements IMonster {
     public void die() {
         int i = this.getSize();
 
-        if (!this.world.isStatic && i > 1 && this.health == 0) {
+        if (!this.world.isStatic && i > 1 && this.health <= 0) {
             for (int j = 0; j < 4; ++j) {
                 float f = ((float) (j % 2) - 0.5F) * (float) i / 4.0F;
                 float f1 = ((float) (j / 2) - 0.5F) * (float) i / 4.0F;


### PR DESCRIPTION
Fixes slime splitting.

Before killing slime with a damage value bigger than one (with a sword for example) would not spawn smaller slimes.