### PR TITLE
Double overflow sent limit

### DIFF
--- a/src/net/minecraft/server/NetworkManager.java
+++ b/src/net/minecraft/server/NetworkManager.java
@@ -237,7 +237,7 @@ public class NetworkManager {
     }
 
     public void b() {
-        if (this.x > 1048576) {
+        if (this.x > 2097152) {
             this.a("disconnect.overflow", new Object[0]);
         }
 


### PR DESCRIPTION
So it turns out my chunk speed fix increased the rate of buffer overflow kicks (it happened on AlphaPlace server)
After doubling the "disconnect.overflow" byte limit (it's like this in modern mc) it seems to have stopped happening.