### PR TITLE
Separate block explosion damage types in EntityDamage events

### DIFF
--- a/src/net/minecraft/server/BlockBed.java
+++ b/src/net/minecraft/server/BlockBed.java
@@ -1,5 +1,7 @@
 package net.minecraft.server;
 
+import org.bukkit.event.entity.EntityDamageEvent;
+
 import java.util.Iterator;
 import java.util.Random;
 
@@ -47,7 +49,7 @@ public class BlockBed extends Block {
                     d2 = (d2 + (double) k + 0.5D) / 2.0D;
                 }
 
-                world.createExplosion((Entity) null, (double) ((float) i + 0.5F), (double) ((float) j + 0.5F), (double) ((float) k + 0.5F), 5.0F, true);
+                world.createExplosion((Entity) null, (double) ((float) i + 0.5F), (double) ((float) j + 0.5F), (double) ((float) k + 0.5F), 5.0F, true, EntityDamageEvent.DamageCause.BED_EXPLOSION); //Project poseidon
                 return true;
             } else {
                 if (e(l)) {

--- a/src/net/minecraft/server/Explosion.java
+++ b/src/net/minecraft/server/Explosion.java
@@ -137,7 +137,6 @@ public class Explosion {
                     // nothing was hurt
                 } else if (this.source == null || this.source instanceof EntityTNTPrimed) { // Block explosion
                     //This event gets fired by tnt, exploding beds, and explosions created by plugins
-                    // TODO: add custom DamageCause for explosions created by plugins
                     // TODO: get the x/y/z of the tnt block?
                     EntityDamageByBlockEvent event;
                     if (this.customDamageCause != null) {
@@ -150,7 +149,6 @@ public class Explosion {
                     server.getPluginManager().callEvent(event);
 
                     if (!event.isCancelled()) {
-                        System.out.println("Damage: " + event.getDamage());
                         entity.damageEntity(this.source, event.getDamage());
                         entity.motX += d0 * d10;
                         entity.motY += d1 * d10;
@@ -158,8 +156,6 @@ public class Explosion {
                         if (sendMotion) { // Poseidon: fix explosion velocity
                             entity.velocityChanged = true;
                         }
-                    }else{
-                        System.out.println("Damage was cancelled");
                     }
                 } else {
                     EntityDamageByEntityEvent event = new EntityDamageByEntityEvent(this.source.getBukkitEntity(), damagee, EntityDamageEvent.DamageCause.ENTITY_EXPLOSION, damageDone);

--- a/src/net/minecraft/server/World.java
+++ b/src/net/minecraft/server/World.java
@@ -1,6 +1,5 @@
 package net.minecraft.server;
 
-import com.legacyminecraft.poseidon.PoseidonConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.BlockState;
@@ -12,6 +11,7 @@ import org.bukkit.event.block.BlockFormEvent;
 import org.bukkit.event.block.BlockPhysicsEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.entity.ItemSpawnEvent;
 import org.bukkit.event.weather.ThunderChangeEvent;
 import org.bukkit.event.weather.WeatherChangeEvent;
@@ -1467,10 +1467,22 @@ public class World implements IBlockAccess {
         return this.createExplosion(entity, d0, d1, d2, f, false);
     }
 
+    //Project Poseidon Start
+    public Explosion createExplosion(Entity entity, double d0, double d1, double d2, float f, boolean flag, EntityDamageEvent.DamageCause customDamageCause) {
+        Explosion explosion = new Explosion(this, entity, d0, d1, d2, f);
+        explosion.customDamageCause = customDamageCause;
+
+        explosion.setFire = flag;
+        explosion.a();
+        explosion.a(true);
+        return explosion;
+    }
+    //Project Poseidon End
+
     public Explosion createExplosion(Entity entity, double d0, double d1, double d2, float f, boolean flag) {
         Explosion explosion = new Explosion(this, entity, d0, d1, d2, f);
 
-        explosion.a = flag;
+        explosion.setFire = flag;
         explosion.a();
         explosion.a(true);
         return explosion;

--- a/src/net/minecraft/server/WorldServer.java
+++ b/src/net/minecraft/server/WorldServer.java
@@ -2,6 +2,7 @@ package net.minecraft.server;
 
 import org.bukkit.BlockChangeDelegate;
 import org.bukkit.craftbukkit.generator.*;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.weather.LightningStrikeEvent;
 import org.bukkit.generator.ChunkGenerator;
 
@@ -136,6 +137,19 @@ public class WorldServer extends World implements BlockChangeDelegate {
         // CraftBukkit
         this.server.getTracker(this.dimension).sendPacketToEntity(entity, packet38entitystatus);
     }
+
+    //Project Poseidon Start
+    public Explosion createExplosion(Entity entity, double d0, double d1, double d2, float f, boolean flag, EntityDamageEvent.DamageCause customDamageCause) {
+        Explosion explosion = super.createExplosion(entity, d0, d1, d2, f, flag, customDamageCause);
+
+        if (explosion.wasCanceled) {
+            return explosion;
+        }
+        this.server.serverConfigurationManager.sendPacketNearby(d0, d1, d2, 64.0D, this.dimension, new Packet60Explosion(d0, d1, d2, f, explosion.blocks));
+
+        return explosion;
+    }
+    //Project Poseidon End
 
     public Explosion createExplosion(Entity entity, double d0, double d1, double d2, float f, boolean flag) {
         // CraftBukkit start

--- a/src/org/bukkit/World.java
+++ b/src/org/bukkit/World.java
@@ -3,6 +3,7 @@ package org.bukkit;
 import org.bukkit.block.Biome;
 import org.bukkit.block.Block;
 import org.bukkit.entity.*;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.generator.BlockPopulator;
 import org.bukkit.generator.ChunkGenerator;
 import org.bukkit.inventory.ItemStack;
@@ -516,6 +517,20 @@ public interface World {
     public boolean createExplosion(double x, double y, double z, float power, boolean setFire);
 
     /**
+     * Creates explosion at given coordinates with given power and DamageCause and optionally setting
+     * blocks on fire.
+     *
+     * @param x
+     * @param y
+     * @param z
+     * @param power The power of explosion, where 4F is TNT
+     * @param setFire Whether or not to set blocks on fire
+     * @param customDamageCause The DamageCause to use for the explosion
+     * @return false if explosion was canceled, otherwise true
+     */
+    public boolean createExplosion(double x, double y, double z, float power, boolean setFire, EntityDamageEvent.DamageCause customDamageCause);
+
+    /**
      * Creates explosion at given coordinates with given power
      *
      * @param loc
@@ -534,6 +549,18 @@ public interface World {
      * @return false if explosion was canceled, otherwise true
      */
     public boolean createExplosion(Location loc, float power, boolean setFire);
+
+    /**
+     * Creates explosion at given coordinates with given power and DamageCause and optionally setting
+     * blocks on fire.
+     *
+     * @param loc
+     * @param power The power of explosion, where 4F is TNT
+     * @param setFire Whether or not to set blocks on fire
+     * @param customDamageCause The DamageCause to use for the explosion
+     * @return false if explosion was canceled, otherwise true
+     */
+    public boolean createExplosion(Location loc, float power, boolean setFire, EntityDamageEvent.DamageCause customDamageCause);
 
     /**
      * Gets the {@link Environment} type of this world

--- a/src/org/bukkit/craftbukkit/CraftWorld.java
+++ b/src/org/bukkit/craftbukkit/CraftWorld.java
@@ -11,6 +11,7 @@ import org.bukkit.craftbukkit.entity.*;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.*;
 import org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason;
+import org.bukkit.event.entity.EntityDamageEvent;
 import org.bukkit.event.weather.ThunderChangeEvent;
 import org.bukkit.event.weather.WeatherChangeEvent;
 import org.bukkit.event.world.SpawnChangeEvent;
@@ -408,7 +409,11 @@ public class CraftWorld implements World {
     }
 
     public boolean createExplosion(double x, double y, double z, float power, boolean setFire) {
-        return world.createExplosion(null, x, y, z, power, setFire).wasCanceled ? false : true;
+        return createExplosion(x, y, z, power, setFire, EntityDamageEvent.DamageCause.PLUGIN_EXPLOSION);
+    }
+
+    public boolean createExplosion(double x, double y, double z, float power, boolean setFire, EntityDamageEvent.DamageCause customDamageCause){
+        return world.createExplosion(null, x, y, z, power, setFire, customDamageCause).wasCanceled ? false : true;
     }
 
     public boolean createExplosion(Location loc, float power) {
@@ -417,6 +422,10 @@ public class CraftWorld implements World {
 
     public boolean createExplosion(Location loc, float power, boolean setFire) {
         return createExplosion(loc.getX(), loc.getY(), loc.getZ(), power, setFire);
+    }
+
+    public boolean createExplosion(Location loc, float power, boolean setFire, EntityDamageEvent.DamageCause customDamageCause){
+        return createExplosion(loc.getX(), loc.getY(), loc.getZ(), power, setFire, customDamageCause);
     }
 
     public Environment getEnvironment() {

--- a/src/org/bukkit/event/entity/EntityDamageEvent.java
+++ b/src/org/bukkit/event/entity/EntityDamageEvent.java
@@ -126,6 +126,18 @@ public class EntityDamageEvent extends EntityEvent implements Cancellable {
          */
         BLOCK_EXPLOSION,
         /**
+         * Damage caused by being in the area when a block of TNT explodes.
+         */
+        TNT_EXPLOSION,
+        /**
+         * Damage caused by being in the area when a bed explodes.
+         */
+        BED_EXPLOSION,
+        /**
+         * Damage caused by being in the area when a plugin causes an explosion
+         */
+        PLUGIN_EXPLOSION,
+        /**
          * Damage caused by being in the area when an entity, such as a Creeper, explodes.
          *
          * Damage: variable


### PR DESCRIPTION
Implements #8 
The only problem I see is if a plugin is expecting to be able to catch all explosion damage events with damage types BLOCK_EXPLOSION and ENTITY_EXPLOSION, they won't catch block explosions or plugin explosions using the default. The new default is that TNT causes TNT_EXPLOSION, beds cause BED_EXPLOSION, and plugins calling CraftWorld.createExplosion without specifying a damage type will cause PLUGIN_EXPLOSION.