### PR TITLE
Add back getUniqueId to Entity

### DIFF
--- a/src/main/java/org/bukkit/entity/Entity.java
+++ b/src/main/java/org/bukkit/entity/Entity.java
@@ -166,4 +166,10 @@ public interface Entity {
      * @return the last known {@link EntityDamageEvent} or null if hitherto unharmed
      */
     public EntityDamageEvent getLastDamageCause();
+
+    /**
+     * Returns a unique and persistent id for this entity
+     * @return unique id
+     */
+    public UUID getUniqueId();
 }


### PR DESCRIPTION
Some plugins that have to deal with entities use the `getUniqueId` from `org/bukkit/Entity`.
It was removed in be91ab4 rendering some plugins unusable.