### PR TITLE
Feature/81 latest log file implementation

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
@@ -62,7 +62,7 @@ public class ServerLogRotator {
 
         // catch any exceptions that occur during the process, and log them. IOExceptions are possible when calling createNewFile()
         } catch (IOException e) {
-            logger.log(Level.SEVERE, "Failed to create new log file!");
+            logger.log(Level.SEVERE, "[Poseidon]  Failed to create new log file!");
             logger.log(Level.SEVERE, e.toString());
         }
     }
@@ -73,13 +73,13 @@ public class ServerLogRotator {
      */
     private void buildHistoricalLogsFromLatestLogFile() {
 
-        logger.log(Level.INFO, "Building logs from latest.log...");
+        logger.log(Level.INFO, "[Poseidon] Building logs from latest.log...");
 
         try {
             // open latest log file
             File latestLog = new File("." + File.separator + "logs" + File.separator + this.latestLogFileName + ".log");
             if (!latestLog.exists()) {
-                logger.log(Level.INFO, "No logs to build from latest.log!");
+                logger.log(Level.INFO, "[Poseidon] No logs to build from latest.log!");
                 return;
             }
 
@@ -118,11 +118,11 @@ public class ServerLogRotator {
             writer.print(todayLogs);
             writer.close();
 
-            logger.log(Level.INFO, "Logs built from latest.log!");
+            logger.log(Level.INFO, "[Poseidon] Logs built from latest.log!");
 
         // catch any exceptions that occur during the process, and log them
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Failed to build logs from latest.log!");
+            logger.log(Level.SEVERE, "[Poseidon] Failed to build logs from latest.log!");
             logger.log(Level.SEVERE, e.toString());
         }
     }
@@ -141,8 +141,8 @@ public class ServerLogRotator {
         buildHistoricalLogsFromLatestLogFile();
 
         // Schedule the log rotation task to run every day at midnight offset by one second to avoid missing logs
-        logger.log(Level.INFO, "Log rotation task scheduled for run in " + initialDelay + " seconds, and then every " + period + " seconds.");
-        logger.log(Level.INFO, "If latest.log contains logs from earlier, not previously archived dates, they will be archived to the appropriate log files " +
+        logger.log(Level.INFO, "[Poseidon] Log rotation task scheduled for run in " + initialDelay + " seconds, and then every " + period + " seconds.");
+        logger.log(Level.INFO, "[Poseidon] If latest.log contains logs from earlier, not previously archived dates, they will be archived to the appropriate log files " +
                                "upon first run of the log rotation task. If log files already exist for these dates, the logs will be appended to the existing log files!");
         Bukkit.getScheduler().scheduleAsyncRepeatingTask(new PoseidonPlugin(), this::buildHistoricalLogsFromLatestLogFile, (initialDelay + 1) * 20, period * 20);
     }

--- a/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
@@ -1,0 +1,97 @@
+package com.legacyminecraft.poseidon.util;
+
+import java.io.File;
+import java.io.PrintWriter;
+import java.nio.file.Files;
+import java.time.Duration;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.time.format.DateTimeFormatter;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
+import java.util.logging.Logger;
+import java.util.logging.*;
+
+/**
+ * The ServerLogRotator class handles the rotation of server logs.
+ * It archives the current log file and creates a new one every day at midnight.
+ */
+public class ServerLogRotator {
+
+    private final ScheduledExecutorService executorService;
+    private final String latestLogFileName;
+
+    /**
+     * Constructor for the ServerLogRotator class.
+     *
+     * @param latestLogFileName The name of the latest log file. This file will be archived by the log rotation task.
+     */
+    public ServerLogRotator(String latestLogFileName) {
+        this.executorService = Executors.newScheduledThreadPool(1);
+        this.latestLogFileName = latestLogFileName;
+    }
+    // end of constructor
+
+    /**
+     * The archiveLog method is responsible for archiving the current log file.
+     * It first checks if the latest log file exists. If it does, it reads its contents,
+     * writes the contents to a new file named with the current date, and then clears the latest log file.
+     * If the latest log file does not exist, it logs a message and does nothing.
+     * If any exception occurs during the process, it logs the exception message.
+     */
+    private void archiveLog() {
+        Logger a = Logger.getLogger("Minecraft");
+        try {
+
+            // Check if the latest.log file exists (if it does not, do nothing)
+            File latestLog = new File("." + File.separator + "logs" + File.separator + this.latestLogFileName + ".log");
+            if (latestLog.exists()) {
+
+                // checks if a log file with the same date already exists (if so, don't overwrite it)
+                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                String archivedLogFileName = LocalDateTime.now().format(formatter);
+                File archivedLogFile = new File("." + File.separator + "logs" + File.separator + archivedLogFileName + ".log");
+                if (archivedLogFile.exists()) { return; }
+
+                // move the latest.log file to a new file with the current date
+                String content = new String(Files.readAllBytes(latestLog.toPath())); // read log file contents
+                Files.write(archivedLogFile.toPath(), content.getBytes()); // write log file contents to new file
+                PrintWriter writer = new PrintWriter(latestLog); // clear the latest log file
+                writer.print("");
+                writer.close();
+            }
+        } catch (Exception e) {
+            a.log(Level.SEVERE, "Failed to move logs!");
+            a.log(Level.SEVERE, e.toString());
+        }
+        a.log(Level.INFO, "Latest.log has not been created! Skipping log rotation..");
+    }
+    // end of archiveLog method
+
+    /**
+     * The start method is used to start the log rotation task.
+     * It calculates the initial delay until the next midnight,
+     * and then schedules the log rotation task with this initial delay and a period of 24 hours.
+     */
+    public void start() {
+
+        ZonedDateTime now = ZonedDateTime.now();
+        ZonedDateTime nextRun = now.withHour(0).withMinute(0).withSecond(0).withNano(0);
+        if(now.compareTo(nextRun) > 0)
+            nextRun = nextRun.plusDays(1);
+
+        Duration duration = Duration.between(now, nextRun);
+        long initialDelay = duration.getSeconds();
+        long period = TimeUnit.DAYS.toSeconds(1);
+
+        // Schedule a task to run every day at midnight
+        executorService.scheduleAtFixedRate(this::archiveLog, initialDelay, period, TimeUnit.SECONDS);
+        // function can be tested by changing the period to 10 seconds, and the initial delay to 0
+        // change the DateTimeFormatter  in archiveLog() to "yyyy-MM-dd-HH-mm-ss"
+    }
+    // end of start method
+
+}
+// end of ServerLogRotator.java
+

--- a/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
@@ -4,12 +4,14 @@ import org.bukkit.Bukkit;
 import com.legacyminecraft.poseidon.PoseidonPlugin;
 
 import java.io.File;
+import java.io.FileWriter;
+import java.io.IOException;
 import java.io.PrintWriter;
 import java.nio.file.Files;
 import java.time.Duration;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
-import java.time.format.DateTimeFormatter;
+import java.util.Arrays;
 import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.logging.*;
@@ -23,31 +25,110 @@ public class ServerLogRotator {
         this.logger = Logger.getLogger("Minecraft");
     }
 
-    private void archiveLog() {
+    /**
+     * Checks if the date in the log line is today's date
+     * @param date The date in the log line. Format: "yyyy-MM-dd"
+     * @return True if the date in the log line is today's date, false otherwise
+     */
+    private boolean isToday(String date) {
+    String[] dateParts = date.split("-");
+        LocalDateTime logLineDateTime = LocalDateTime.of(Integer.parseInt(dateParts[0]), Integer.parseInt(dateParts[1]), Integer.parseInt(dateParts[2]), 0, 0, 0);
+        LocalDateTime now = LocalDateTime.now();
+        return logLineDateTime.getYear() == now.getYear() && logLineDateTime.getMonthValue() == now.getMonthValue() && logLineDateTime.getDayOfMonth() == now.getDayOfMonth();
+    }
+
+    /**
+     * Archives a log line to a log file with the same date as the date in the log line
+     * @param parts The log line to archive to a log file haven been split already e.g. ["2024-03-20", "13:02:27", "[INFO]", "This is a log message..."]
+     */
+    private void archiveLine(String[] parts) {
+
         try {
-            logger.log(Level.INFO, "Archiving contents of latest.log to a new file!");
-            // Check if the latest.log file exists (if it does not, do nothing)
-            File latestLog = new File("." + File.separator + "logs" + File.separator + this.latestLogFileName + ".log");
-            if (latestLog.exists()) {
-                // checks if a log file with the same date already exists (if so, don't overwrite it)
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                String archivedLogFileName = LocalDateTime.now().minusDays(1).format(formatter);
-                File archivedLogFile = new File("." + File.separator + "logs" + File.separator + archivedLogFileName + ".log");
-                if (archivedLogFile.exists()) { return; }
-                // move the latest.log file to a new file with the current date
-                String content = new String(Files.readAllBytes(latestLog.toPath()));
-                Files.write(archivedLogFile.toPath(), content.getBytes());
-                PrintWriter writer = new PrintWriter(latestLog);
-                writer.print("");
-                writer.close();
+
+            String date = parts[0];
+            String time = parts[1];
+            String logLevel = parts[2];
+            String message = String.join(" ", Arrays.copyOfRange(parts, 3, parts.length));
+            // check if a log file with this information already exists
+            File logFile = new File("." + File.separator + "logs" + File.separator + date + ".log");
+            if (!logFile.exists()) {
+                logFile.createNewFile();
             }
+            // append the log line to the log file with the same date as the date in the log line
+            FileWriter fileWriter = new FileWriter(logFile, true);
+            PrintWriter writer = new PrintWriter(fileWriter);
+            writer.println(date + " " + time + " " + logLevel + " " + message);
+            writer.close();
+
+        // catch any exceptions that occur during the process, and log them. IOExceptions are possible when calling createNewFile()
+        } catch (IOException e) {
+            logger.log(Level.SEVERE, "Failed to create new log file!");
+            logger.log(Level.SEVERE, e.toString());
+        }
+    }
+
+    /**
+     * Builds historical logs from the latest.log file. Logs from today's date are kept in the latest.log file, while logs from previous dates are archived to log files with the same date as the date in the log line.
+     * Note that if latest.log contains logs from multiple days, the logs will be split by date and archived to the appropriate log files.
+     */
+    private void buildHistoricalLogsFromLatestLogFile() {
+
+        logger.log(Level.INFO, "Building logs from latest.log...");
+
+        try {
+            // open latest log file
+            File latestLog = new File("." + File.separator + "logs" + File.separator + this.latestLogFileName + ".log");
+            if (!latestLog.exists()) {
+                logger.log(Level.INFO, "No logs to build from latest.log!");
+                return;
+            }
+
+            // split the contents of the latest log file by line (and strip the newline character)
+            String content = new String(Files.readAllBytes(latestLog.toPath()));
+            String[] lines = content.split("\n");
+            // create a StringBuilder to store today's logs (to write back to latest.log after archiving the rest of the logs)
+            StringBuilder todayLogs = new StringBuilder();
+
+            for (String line : lines) {
+
+                String[] splitLine = line.split(" ");
+                if (splitLine.length < 3) { // all lines will start with a date, time, and log level e.g. "2024-03-20 13:02:27 [INFO]"
+                    continue;
+                }
+
+                // make sure the first index is a date
+                if (!splitLine[0].matches("\\d{4}-\\d{2}-\\d{2}")) {
+                    continue;
+                }
+
+                // if the log line is of today's date, do not archive it (ignore times)
+                if (isToday(splitLine[0])) {
+                    todayLogs.append(line).append("\n");
+                    continue;
+                }
+
+                // archive the log line to a log file with the same date as the date in the log line
+                archiveLine(splitLine);
+
+            }
+
+            // clear latest.log and write back today's logs from the StringBuilder
+            FileWriter fileWriter = new FileWriter(latestLog);
+            PrintWriter writer = new PrintWriter(fileWriter);
+            writer.print(todayLogs);
+            writer.close();
+
+            logger.log(Level.INFO, "Logs built from latest.log!");
+
+        // catch any exceptions that occur during the process, and log them
         } catch (Exception e) {
-            logger.log(Level.SEVERE, "Failed to move logs!");
+            logger.log(Level.SEVERE, "Failed to build logs from latest.log!");
             logger.log(Level.SEVERE, e.toString());
         }
     }
 
     public void start() {
+        // Calculate the initial delay and period for the log rotation task
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime nextRun = now.withHour(0).withMinute(0).withSecond(0).withNano(0);
         if(now.compareTo(nextRun) > 0)
@@ -55,9 +136,15 @@ public class ServerLogRotator {
         Duration duration = Duration.between(now, nextRun);
         long initialDelay = duration.getSeconds();
         long period = TimeUnit.DAYS.toSeconds(1);
-        // Schedule the log rotation task
-        logger.log(Level.INFO, "Log rotation task scheduled for first run in " + initialDelay + " seconds, and then every " + period + " seconds.");
-        Bukkit.getScheduler().scheduleAsyncRepeatingTask(new PoseidonPlugin(), this::archiveLog, initialDelay * 20, period * 20);
+
+        // do log rotation immediately upon startup to ensure that logs are archived correctly.
+        buildHistoricalLogsFromLatestLogFile();
+
+        // Schedule the log rotation task to run every day at midnight offset by one second to avoid missing logs
+        logger.log(Level.INFO, "Log rotation task scheduled for run in " + initialDelay + " seconds, and then every " + period + " seconds.");
+        logger.log(Level.INFO, "If latest.log contains logs from earlier, not previously archived dates, they will be archived to the appropriate log files " +
+                               "upon first run of the log rotation task. If log files already exist for these dates, the logs will be appended to the existing log files!");
+        Bukkit.getScheduler().scheduleAsyncRepeatingTask(new PoseidonPlugin(), this::buildHistoricalLogsFromLatestLogFile, (initialDelay + 1) * 20, period * 20);
     }
 }
 

--- a/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
@@ -21,7 +21,7 @@ import java.util.logging.*;
 public class ServerLogRotator {
 
     private final String latestLogFileName;
-    private final Logger a;
+    private final Logger logger;
 
     /**
      * Constructor for the ServerLogRotator class.
@@ -30,7 +30,7 @@ public class ServerLogRotator {
      */
     public ServerLogRotator(String latestLogFileName) {
         this.latestLogFileName = latestLogFileName;
-        this.a = Logger.getLogger("Minecraft");
+        this.logger = Logger.getLogger("Minecraft");
     }
     // end of constructor
 
@@ -44,7 +44,7 @@ public class ServerLogRotator {
     private void archiveLog() {
         try {
 
-            this.a.log(Level.INFO, "Archiving contents of latest.log to a new file!");
+            logger.log(Level.INFO, "Archiving contents of latest.log to a new file!");
 
             // Check if the latest.log file exists (if it does not, do nothing)
             File latestLog = new File("." + File.separator + "logs" + File.separator + this.latestLogFileName + ".log");
@@ -66,8 +66,8 @@ public class ServerLogRotator {
                 writer.close();
             }
         } catch (Exception e) {
-            this.a.log(Level.SEVERE, "Failed to move logs!");
-            this.a.log(Level.SEVERE, e.toString());
+            logger.log(Level.SEVERE, "Failed to move logs!");
+            logger.log(Level.SEVERE, e.toString());
         }
     }
     // end of archiveLog method
@@ -89,7 +89,7 @@ public class ServerLogRotator {
         long period = TimeUnit.DAYS.toSeconds(1);
 
         // Schedule the log rotation task
-        this.a.log(Level.INFO, "Log rotation task scheduled for first run in " + initialDelay + " seconds, and then every " + period + " seconds.");
+        logger.log(Level.INFO, "Log rotation task scheduled for first run in " + initialDelay + " seconds, and then every " + period + " seconds.");
         Bukkit.getScheduler().scheduleAsyncRepeatingTask(new PoseidonPlugin(), this::archiveLog, initialDelay * 20, period * 20);
         // function can be tested by changing the period to 10 seconds, and the initial delay to 0
         // change the DateTimeFormatter  in archiveLog() to "yyyy-MM-dd-HH-mm" to test the log rotation every min

--- a/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/ServerLogRotator.java
@@ -14,54 +14,30 @@ import java.util.concurrent.TimeUnit;
 import java.util.logging.Logger;
 import java.util.logging.*;
 
-/**
- * The ServerLogRotator class handles the rotation of server logs.
- * It archives the current log file and creates a new one every day at midnight.
- */
 public class ServerLogRotator {
-
     private final String latestLogFileName;
     private final Logger logger;
 
-    /**
-     * Constructor for the ServerLogRotator class.
-     *
-     * @param latestLogFileName The name of the latest log file. This file will be archived by the log rotation task.
-     */
     public ServerLogRotator(String latestLogFileName) {
         this.latestLogFileName = latestLogFileName;
         this.logger = Logger.getLogger("Minecraft");
     }
-    // end of constructor
 
-    /**
-     * The archiveLog method is responsible for archiving the current log file.
-     * It first checks if the latest log file exists. If it does, it reads its contents,
-     * writes the contents to a new file named with the current date, and then clears the latest log file.
-     * If the latest log file does not exist, it logs a message and does nothing.
-     * If any exception occurs during the process, it logs the exception message.
-     */
     private void archiveLog() {
         try {
-
             logger.log(Level.INFO, "Archiving contents of latest.log to a new file!");
-
             // Check if the latest.log file exists (if it does not, do nothing)
             File latestLog = new File("." + File.separator + "logs" + File.separator + this.latestLogFileName + ".log");
             if (latestLog.exists()) {
-
                 // checks if a log file with the same date already exists (if so, don't overwrite it)
                 DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
                 String archivedLogFileName = LocalDateTime.now().minusDays(1).format(formatter);
-//                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd-HH-mm"); // debug
-//                String archivedLogFileName = LocalDateTime.now().minusMinutes(1).format(formatter); // debug
                 File archivedLogFile = new File("." + File.separator + "logs" + File.separator + archivedLogFileName + ".log");
                 if (archivedLogFile.exists()) { return; }
-
                 // move the latest.log file to a new file with the current date
-                String content = new String(Files.readAllBytes(latestLog.toPath())); // read log file contents
-                Files.write(archivedLogFile.toPath(), content.getBytes()); // write log file contents to new file
-                PrintWriter writer = new PrintWriter(latestLog); // clear the latest log file
+                String content = new String(Files.readAllBytes(latestLog.toPath()));
+                Files.write(archivedLogFile.toPath(), content.getBytes());
+                PrintWriter writer = new PrintWriter(latestLog);
                 writer.print("");
                 writer.close();
             }
@@ -70,32 +46,18 @@ public class ServerLogRotator {
             logger.log(Level.SEVERE, e.toString());
         }
     }
-    // end of archiveLog method
 
-    /**
-     * The start method is used to start the log rotation task.
-     * It calculates the initial delay until the next midnight,
-     * and then schedules the log rotation task with this initial delay and a period of 24 hours.
-     */
     public void start() {
-
         ZonedDateTime now = ZonedDateTime.now();
         ZonedDateTime nextRun = now.withHour(0).withMinute(0).withSecond(0).withNano(0);
         if(now.compareTo(nextRun) > 0)
             nextRun = nextRun.plusDays(1);
-
         Duration duration = Duration.between(now, nextRun);
         long initialDelay = duration.getSeconds();
         long period = TimeUnit.DAYS.toSeconds(1);
-
         // Schedule the log rotation task
         logger.log(Level.INFO, "Log rotation task scheduled for first run in " + initialDelay + " seconds, and then every " + period + " seconds.");
         Bukkit.getScheduler().scheduleAsyncRepeatingTask(new PoseidonPlugin(), this::archiveLog, initialDelay * 20, period * 20);
-        // function can be tested by changing the period to 10 seconds, and the initial delay to 0
-        // change the DateTimeFormatter  in archiveLog() to "yyyy-MM-dd-HH-mm" to test the log rotation every min
     }
-    // end of start method
-
 }
-// end of ServerLogRotator.java
 

--- a/src/main/java/net/minecraft/server/ConsoleLogManager.java
+++ b/src/main/java/net/minecraft/server/ConsoleLogManager.java
@@ -1,11 +1,12 @@
 package net.minecraft.server;
 
 import com.legacyminecraft.poseidon.PoseidonConfig;
-import com.legacyminecraft.poseidon.util.ServerLogRotator;
 import org.bukkit.craftbukkit.util.ShortConsoleLogFormatter;
 import org.bukkit.craftbukkit.util.TerminalConsoleHandler;
 
 import java.io.File;
+import java.time.LocalDate;
+import java.time.format.DateTimeFormatter;
 import java.util.logging.*;
 
 // CraftBukkit start
@@ -40,13 +41,23 @@ public class ConsoleLogManager {
         try {
             //Project Poseidon Start
             FileHandler filehandler;
-            if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-logfile")) {
-                String latestLogFileName = "latest";
-                File log = new File("." + File.separator + "logs" + File.separator);
-                log.getParentFile().mkdirs();
-                log.mkdirs();
-                filehandler = new FileHandler("." + File.separator + "logs" + File.separator + latestLogFileName + ".log", true);
-
+            if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-log-file.enabled")) {
+                //If latest log file is enabled, create a new log file for each day
+                if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-log-file.latest-log.enabled")) {
+                    String latestLogFileName = "latest";
+                    File log = new File("." + File.separator + "logs" + File.separator);
+                    log.getParentFile().mkdirs();
+                    log.mkdirs();
+                    filehandler = new FileHandler("." + File.separator + "logs" + File.separator + latestLogFileName + ".log", true);
+                } else {
+                    //If latest log file is disabled, create a new log file for each day with the date as the file name
+                    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
+                    String logfile = LocalDate.now().format(formatter);
+                    File log = new File("." + File.separator + "logs" + File.separator);
+                    log.getParentFile().mkdirs();
+                    log.mkdirs();
+                    filehandler = new FileHandler("." + File.separator + "logs" + File.separator + logfile + ".log", true);
+                }
             } else {
                 // CraftBukkit start
                 String pattern = (String) server.options.valueOf("log-pattern");

--- a/src/main/java/net/minecraft/server/ConsoleLogManager.java
+++ b/src/main/java/net/minecraft/server/ConsoleLogManager.java
@@ -1,12 +1,11 @@
 package net.minecraft.server;
 
 import com.legacyminecraft.poseidon.PoseidonConfig;
+import com.legacyminecraft.poseidon.util.ServerLogRotator;
 import org.bukkit.craftbukkit.util.ShortConsoleLogFormatter;
 import org.bukkit.craftbukkit.util.TerminalConsoleHandler;
 
 import java.io.File;
-import java.time.LocalDate;
-import java.time.format.DateTimeFormatter;
 import java.util.logging.*;
 
 // CraftBukkit start
@@ -42,12 +41,15 @@ public class ConsoleLogManager {
             //Project Poseidon Start
             FileHandler filehandler;
             if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-logfile")) {
-                DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd");
-                String logfile = LocalDate.now().format(formatter);
+                String latestLogFileName = "latest";
                 File log = new File("." + File.separator + "logs" + File.separator);
                 log.getParentFile().mkdirs();
                 log.mkdirs();
-                filehandler = new FileHandler("." + File.separator + "logs" + File.separator + logfile + ".log", true);
+                filehandler = new FileHandler("." + File.separator + "logs" + File.separator + latestLogFileName + ".log", true);
+                // Start the server log rotator (scheduled task)
+                ServerLogRotator serverLogRotator = new ServerLogRotator(latestLogFileName);
+                serverLogRotator.start();
+
             } else {
                 // CraftBukkit start
                 String pattern = (String) server.options.valueOf("log-pattern");
@@ -58,7 +60,6 @@ public class ConsoleLogManager {
                 // CraftBukkit start
             }
             //Project Poseidon End
-
 
             filehandler.setFormatter(consolelogformatter);
             a.addHandler(filehandler);

--- a/src/main/java/net/minecraft/server/ConsoleLogManager.java
+++ b/src/main/java/net/minecraft/server/ConsoleLogManager.java
@@ -46,9 +46,6 @@ public class ConsoleLogManager {
                 log.getParentFile().mkdirs();
                 log.mkdirs();
                 filehandler = new FileHandler("." + File.separator + "logs" + File.separator + latestLogFileName + ".log", true);
-                // Start the server log rotator (scheduled task)
-                ServerLogRotator serverLogRotator = new ServerLogRotator(latestLogFileName);
-                serverLogRotator.start();
 
             } else {
                 // CraftBukkit start

--- a/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -1,6 +1,7 @@
 package net.minecraft.server;
 
 import com.legacyminecraft.poseidon.PoseidonConfig;
+import com.legacyminecraft.poseidon.util.ServerLogRotator;
 import com.projectposeidon.johnymuffin.UUIDManager;
 import com.legacyminecraft.poseidon.watchdog.WatchDogThread;
 import jline.ConsoleReader;
@@ -398,6 +399,12 @@ public class MinecraftServer implements Runnable, ICommandListener {
         try {
             if (this.init()) {
                 long i = System.currentTimeMillis();
+
+                if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-logfile")) {
+                    String latestLogFileName = "latest";
+                    ServerLogRotator serverLogRotator = new ServerLogRotator(latestLogFileName);
+                    serverLogRotator.start();
+                }
 
                 for (long j = 0L; this.isRunning; Thread.sleep(1L)) {
                     if (modLoaderSupport) {

--- a/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -198,6 +198,13 @@ public class MinecraftServer implements Runnable, ICommandListener {
         String time = String.format("%.3fs", elapsed / 10000000000.0D);
         log.info("Done (" + time + ")! For help, type \"help\" or \"?\"");
 
+        // log rotator process start.
+        if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-logfile")) {
+            String latestLogFileName = "latest";
+            ServerLogRotator serverLogRotator = new ServerLogRotator(latestLogFileName);
+            serverLogRotator.start();
+        }
+
         if (this.propertyManager.properties.containsKey("spawn-protection")) {
             log.info("'spawn-protection' in server.properties has been moved to 'settings.spawn-radius' in bukkit.yml. I will move your config for you.");
             this.server.setSpawnRadius(this.propertyManager.getInt("spawn-protection", 16));
@@ -399,12 +406,6 @@ public class MinecraftServer implements Runnable, ICommandListener {
         try {
             if (this.init()) {
                 long i = System.currentTimeMillis();
-
-                if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-logfile")) {
-                    String latestLogFileName = "latest";
-                    ServerLogRotator serverLogRotator = new ServerLogRotator(latestLogFileName);
-                    serverLogRotator.start();
-                }
 
                 for (long j = 0L; this.isRunning; Thread.sleep(1L)) {
                     if (modLoaderSupport) {

--- a/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -199,7 +199,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
         log.info("Done (" + time + ")! For help, type \"help\" or \"?\"");
 
         // log rotator process start.
-        if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-logfile")) {
+        if ((boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-log-file.enabled") && (boolean) PoseidonConfig.getInstance().getConfigOption("settings.per-day-log-file.latest-log.enabled")) {
             String latestLogFileName = "latest";
             ServerLogRotator serverLogRotator = new ServerLogRotator(latestLogFileName);
             serverLogRotator.start();


### PR DESCRIPTION
In solution to ticket #81, I implemented the latest.log logic. 

All information is logged to latest.log, and upon 00:00 local time, an event is triggered, rotating the information out of `latest.log`, and pushed to a log file in the format `yy-MM-dd.log` containing that day's log files.