### PR TITLE
fixed lags caused by ghasts in high distances

### DIFF
--- a/src/main/java/net/minecraft/server/EntityGhast.java
+++ b/src/main/java/net/minecraft/server/EntityGhast.java
@@ -51,9 +51,7 @@ public class EntityGhast extends EntityFlying implements IMonster {
             this.b = this.locX + (double) ((this.random.nextFloat() * 2.0F - 1.0F) * 16.0F);
             this.c = this.locY + (double) ((this.random.nextFloat() * 2.0F - 1.0F) * 16.0F);
             this.d = this.locZ + (double) ((this.random.nextFloat() * 2.0F - 1.0F) * 16.0F);
-        }
-
-        if (this.a-- <= 0) {
+        } else if (this.a-- <= 0) {
             this.a += this.random.nextInt(5) + 2;
             if (this.a(this.b, this.c, this.d, d3)) {
                 this.motX += d0 / d3 * 0.1D;


### PR DESCRIPTION
The lags were caused by the loop in `EntityGhast::a` which used distance from entity to 0/0/0 after spawning(d3). 
If the ghast spawned far from 0/0/0 (in farlands, for example), it would have to get entities ~12m times.