### PR TITLE
Fix for issue #98 (Player#getInventory#getArmorContents is always AIR)

### DIFF
--- a/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
+++ b/src/main/java/org/bukkit/craftbukkit/inventory/CraftInventoryPlayer.java
@@ -1,8 +1,11 @@
 package org.bukkit.craftbukkit.inventory;
 
 import net.minecraft.server.InventoryPlayer;
+import org.bukkit.Material;
 import org.bukkit.inventory.ItemStack;
 import org.bukkit.inventory.PlayerInventory;
+
+import java.util.ArrayList;
 
 public class CraftInventoryPlayer extends CraftInventory implements PlayerInventory {
     public CraftInventoryPlayer(net.minecraft.server.InventoryPlayer inventory) {
@@ -42,7 +45,7 @@ public class CraftInventoryPlayer extends CraftInventory implements PlayerInvent
     }
 
     public ItemStack getBoots() {
-        return getItem(getSize() + 0);
+        return getItem(getSize());
     }
 
     public void setHelmet(ItemStack helmet) {
@@ -58,17 +61,33 @@ public class CraftInventoryPlayer extends CraftInventory implements PlayerInvent
     }
 
     public void setBoots(ItemStack boots) {
-        setItem(getSize() + 0, boots);
+        setItem(getSize(), boots);
     }
 
-    public CraftItemStack[] getArmorContents() {
-        net.minecraft.server.ItemStack[] mcItems = getInventory().getArmorContents();
-        CraftItemStack[] ret = new CraftItemStack[mcItems.length];
+    public ItemStack[] getArmorContents() {
+        ArrayList<ItemStack> contents = new ArrayList<>();
 
-        for (int i = 0; i < mcItems.length; i++) {
-            ret[i] = new CraftItemStack(mcItems[i]);
+        ItemStack boots = getItem(getSize());
+        if (boots != null && boots.getType() != Material.AIR) {
+            contents.add(boots);
         }
-        return ret;
+
+        ItemStack leggings = getItem(getSize() + 1);
+        if (leggings != null && leggings.getType() != Material.AIR) {
+            contents.add(leggings);
+        }
+
+        ItemStack chestplate = getItem(getSize() + 2);
+        if (chestplate != null && chestplate.getType() != Material.AIR) {
+            contents.add(chestplate);
+        }
+
+        ItemStack helmet = getItem(getSize() + 3);
+        if (helmet != null && helmet.getType() != Material.AIR) {
+            contents.add(helmet);
+        }
+
+        return contents.toArray(new ItemStack[0]);
     }
 
     public void setArmorContents(ItemStack[] items) {


### PR DESCRIPTION
Tested and works. Method successfully returns ItemStack[] of player equipped armor. Returns empty if nothing equipped.

Full armor:
![image](https://github.com/user-attachments/assets/e18c2736-7536-402c-b041-2a77ba9d61a6)
Some armor:
![image](https://github.com/user-attachments/assets/f2e9c657-21ba-4e38-95da-7f460648770d)
No armor:
![image](https://github.com/user-attachments/assets/2c2686c9-61a3-4913-95af-004d4ae87d2e)

Code used for testing purposes:
```
package org.example;

import org.bukkit.entity.Player;
import org.bukkit.event.EventHandler;
import org.bukkit.event.player.PlayerListener;
import org.bukkit.event.player.PlayerMoveEvent;
import org.bukkit.inventory.ItemStack;
import org.bukkit.inventory.PlayerInventory;

import java.util.Arrays;

public class PlayerMoveListener extends PlayerListener {

    @EventHandler
    public void onPlayerMove(PlayerMoveEvent event) {
        Player player = event.getPlayer();
        PlayerInventory inventory = player.getInventory();
        ItemStack[] contents = inventory.getArmorContents();
        player.sendMessage(Arrays.toString(contents));
    }
}
```
