### PR TITLE
Fix blocks only harvestable with tool not dropping item on last tool use

### DIFF
--- a/src/main/java/net/minecraft/server/ItemInWorldManager.java
+++ b/src/main/java/net/minecraft/server/ItemInWorldManager.java
@@ -177,17 +177,17 @@ public class ItemInWorldManager {
         boolean flag = this.b(i, j, k);
         ItemStack itemstack = this.player.G();
 
+        if (flag && this.player.b(Block.byId[l])) {
+            Block.byId[l].a(this.world, this.player, i, j, k, i1);
+            ((EntityPlayer) this.player).netServerHandler.sendPacket(new Packet53BlockChange(i, j, k, this.world));
+        }
+
         if (itemstack != null) {
             itemstack.a(l, i, j, k, this.player);
             if (itemstack.count == 0) {
                 itemstack.a(this.player);
                 this.player.H();
             }
-        }
-
-        if (flag && this.player.b(Block.byId[l])) {
-            Block.byId[l].a(this.world, this.player, i, j, k, i1);
-            ((EntityPlayer) this.player).netServerHandler.sendPacket(new Packet53BlockChange(i, j, k, this.world));
         }
 
         return flag;


### PR DESCRIPTION
When a block that can only be harvested with a tool (e.g. stone can only be harvested with a pickaxe) is broken and the tool is at 0 durability, nothing is dropped. This is because the tool is deleted before the server can check if the right tool is used to break the block in order to harvest it. This pull request fixes this.

```java
...
ItemStack itemstack = this.player.G(); //get item in hand

        if (flag && this.player.b(Block.byId[l])) { //can player harvest block
            Block.byId[l].a(this.world, this.player, i, j, k, i1); //harvest block
            ((EntityPlayer) this.player).netServerHandler.sendPacket(new Packet53BlockChange(i, j, k, this.world));
        }

        if (itemstack != null) {
            itemstack.a(l, i, j, k, this.player); //increment statistic for tool usage
            if (itemstack.count == 0) {
                itemstack.a(this.player); //does literally nothing
                this.player.H(); //delete item
            }
        }
...
```