### PR TITLE
Add chest open event

### DIFF
--- a/src/main/java/net/minecraft/server/EntityPlayer.java
+++ b/src/main/java/net/minecraft/server/EntityPlayer.java
@@ -7,8 +7,8 @@ import org.bukkit.Bukkit;
 import org.bukkit.craftbukkit.ChunkCompressionThread;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.craftbukkit.inventory.CraftItemStack;
-import org.bukkit.event.entity.EntityDeathEvent;
 import org.bukkit.event.entity.EntityRegainHealthEvent.RegainReason;
+import org.bukkit.event.inventory.ChestOpenedEvent;
 
 import java.util.*;
 
@@ -455,6 +455,12 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
 
     public void a(IInventory iinventory) {
         this.ai();
+
+        // Poseidon start
+        ChestOpenedEvent event = new ChestOpenedEvent((org.bukkit.entity.Player) this.getBukkitEntity(), iinventory.getContents());
+        this.world.getServer().getPluginManager().callEvent(event);
+        if (event.isCancelled()) return;
+        // Poseidon end
 
         this.netServerHandler.sendPacket(new Packet100OpenWindow(this.bO, 0, iinventory.getName(), iinventory.getSize()));
         this.activeContainer = new ContainerChest(this.inventory, iinventory);

--- a/src/main/java/net/minecraft/server/IInventory.java
+++ b/src/main/java/net/minecraft/server/IInventory.java
@@ -18,5 +18,5 @@ public interface IInventory {
 
     boolean a_(EntityHuman entityhuman);
 
-    public abstract ItemStack[] getContents(); // CraftBukkit
+    ItemStack[] getContents(); // CraftBukkit
 }

--- a/src/main/java/org/bukkit/event/Event.java
+++ b/src/main/java/org/bukkit/event/Event.java
@@ -140,7 +140,7 @@ public abstract class Event implements Serializable {
     /**
      * Provides a lookup for all core events
      *
-     * @see org.bukkit.event.
+     * @see org.bukkit.event
      */
     public enum Type {
 
@@ -154,6 +154,7 @@ public abstract class Event implements Serializable {
 
         PACKET_RECEIVED(Category.PACKET),
 
+        CHEST_OPENED(Category.BLOCK),
 
         /**
          * Called when a player first starts their connection. Called before UUID is known.

--- a/src/main/java/org/bukkit/event/inventory/ChestOpenedEvent.java
+++ b/src/main/java/org/bukkit/event/inventory/ChestOpenedEvent.java
@@ -1,0 +1,34 @@
+package org.bukkit.event.inventory;
+
+import net.minecraft.server.ItemStack;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Cancellable;
+import org.bukkit.event.Event;
+
+public class ChestOpenedEvent extends Event implements Cancellable {
+    private boolean cancelled;
+    private Player player;
+    private ItemStack[] contents;
+
+    public ChestOpenedEvent(Player player, ItemStack[] contents) {
+        super(Type.CHEST_OPENED);
+        this.player = player;
+        this.contents = contents;
+    }
+
+    public Player getPlayer() {
+        return player;
+    }
+
+    public ItemStack[] getContents() {
+        return contents;
+    }
+
+    public boolean isCancelled() {
+        return cancelled;
+    }
+
+    public void setCancelled(boolean cancel) {
+        this.cancelled = cancel;
+    }
+}


### PR DESCRIPTION
Allows for an event check to see which player opened a chest and to see what its inventory was before player made any changes to it.

EDIT: Tested and works

NOTE: Accidentally made commit with my alt if anyone is wondering who that might be