### PR TITLE
feat: Add UUID integration for bans, whitelist and ops

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -57,6 +57,7 @@ public class PoseidonConfig extends Configuration {
 //        generateConfigOption("settings.allow-graceful-uuids", true);
         generateConfigOption("settings.delete-duplicate-uuids", false);
         generateConfigOption("settings.save-playerdata-by-uuid", true);
+        generateConfigOption("settings.use-uuid-based-player-lists", false);
         // Log management and rotation
         generateConfigOption("settings.per-day-log-file.info", "This setting causes the server to create a new log file each day. This is useful for log rotation and log file management.");
         generateConfigOption("settings.per-day-log-file.enabled", false);

--- a/src/main/java/com/legacyminecraft/poseidon/util/UUIDPlayerList.java
+++ b/src/main/java/com/legacyminecraft/poseidon/util/UUIDPlayerList.java
@@ -1,0 +1,119 @@
+package com.legacyminecraft.poseidon.util;
+
+import com.google.gson.Gson;
+import com.google.gson.GsonBuilder;
+import com.google.gson.reflect.TypeToken;
+
+import java.io.*;
+import java.lang.reflect.Type;
+import java.util.*;
+import java.util.logging.Logger;
+
+/**
+ * Dual-indexed player list storing entries by both UUID and lowercase name.
+ * Used for UUID-based ops, bans, and whitelist storage.
+ */
+public class UUIDPlayerList {
+
+    private static final Logger logger = Logger.getLogger("Minecraft");
+    private static final Gson gson = new GsonBuilder().setPrettyPrinting().create();
+    private static final Type LIST_TYPE = new TypeToken<List<PlayerListEntry>>() {}.getType();
+
+    private final Map<UUID, PlayerListEntry> byUUID = new LinkedHashMap<>();
+    private final Map<String, PlayerListEntry> byName = new LinkedHashMap<>();
+
+    public static class PlayerListEntry {
+        public UUID uuid;
+        public String name;
+
+        public PlayerListEntry() {}
+
+        public PlayerListEntry(UUID uuid, String name) {
+            this.uuid = uuid;
+            this.name = name;
+        }
+    }
+
+    public boolean containsUUID(UUID uuid) {
+        return byUUID.containsKey(uuid);
+    }
+
+    public boolean containsName(String name) {
+        return byName.containsKey(name.toLowerCase());
+    }
+
+    public void add(UUID uuid, String name) {
+        PlayerListEntry entry = new PlayerListEntry(uuid, name);
+        // Remove any existing entry with this UUID or name to avoid duplicates
+        removeByUUID(uuid);
+        removeByName(name);
+        byUUID.put(uuid, entry);
+        byName.put(name.toLowerCase(), entry);
+    }
+
+    public void removeByUUID(UUID uuid) {
+        PlayerListEntry entry = byUUID.remove(uuid);
+        if (entry != null) {
+            byName.remove(entry.name.toLowerCase());
+        }
+    }
+
+    public void removeByName(String name) {
+        PlayerListEntry entry = byName.remove(name.toLowerCase());
+        if (entry != null) {
+            byUUID.remove(entry.uuid);
+        }
+    }
+
+    public Set<String> getNames() {
+        Set<String> names = new HashSet<>();
+        for (PlayerListEntry entry : byUUID.values()) {
+            names.add(entry.name.toLowerCase());
+        }
+        return names;
+    }
+
+    public Collection<PlayerListEntry> entries() {
+        return Collections.unmodifiableCollection(byUUID.values());
+    }
+
+    public void clear() {
+        byUUID.clear();
+        byName.clear();
+    }
+
+    public boolean loadFromJson(File file) {
+        if (!file.exists()) {
+            return false;
+        }
+        try (Reader reader = new FileReader(file)) {
+            List<PlayerListEntry> entries = gson.fromJson(reader, LIST_TYPE);
+            if (entries != null) {
+                clear();
+                for (PlayerListEntry entry : entries) {
+                    if (entry.uuid != null && entry.name != null) {
+                        byUUID.put(entry.uuid, entry);
+                        byName.put(entry.name.toLowerCase(), entry);
+                    }
+                }
+            }
+            return true;
+        } catch (Exception e) {
+            logger.warning("Failed to load UUID player list from " + file.getName() + ": " + e);
+            return false;
+        }
+    }
+
+    public void saveToJson(File file) {
+        try (Writer writer = new FileWriter(file)) {
+            List<PlayerListEntry> entries = new ArrayList<>(byUUID.values());
+            gson.toJson(entries, LIST_TYPE, writer);
+        } catch (Exception e) {
+            logger.warning("Failed to save UUID player list to " + file.getName() + ": " + e);
+        }
+    }
+
+    public int size() {
+        return byUUID.size();
+    }
+}

--- a/src/main/java/net/minecraft/server/ServerConfigurationManager.java
+++ b/src/main/java/net/minecraft/server/ServerConfigurationManager.java
@@ -2,10 +2,14 @@ package net.minecraft.server;
 
 import com.legacyminecraft.poseidon.Poseidon;
 import com.legacyminecraft.poseidon.PoseidonConfig;
+import com.legacyminecraft.poseidon.util.UUIDPlayerList;
+import com.projectposeidon.johnymuffin.UUIDManager;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
+import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftServer;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.bukkit.craftbukkit.PortalTravelAgent;
 import org.bukkit.craftbukkit.command.ColouredConsoleSender;
 import org.bukkit.entity.Player;
 import org.bukkit.event.player.*;
@@ -25,15 +29,23 @@ public class ServerConfigurationManager {
     // private PlayerManager[] d = new PlayerManager[2]; // CraftBukkit - removed
     public int maxPlayers; // CraftBukkit - private -> public
     public Set banByName = new HashSet(); // CraftBukkit - private -> public
-    public Set banByIP = new HashSet(); // CraftBukkit - private -> public
-    private Set h = new HashSet();
-    private Set i = new HashSet();
+    public Set banByIP = new HashSet<String>(); // CraftBukkit - private -> public
+    private Set h = new HashSet(); // operators list
+    private Set i = new HashSet(); // players whitelist
     private File j;
     private File k;
-    private File l;
-    private File m;
+    private File l; // operators plain text file
+    private File m; // whitelist plain text file
     public PlayerFileData playerFileData; // CraftBukkit - private - >public
     public boolean o; // Craftbukkit - private -> public
+
+    // Poseidon UUID-based player lists
+    private UUIDPlayerList bansByUUID = new UUIDPlayerList();
+    private UUIDPlayerList opsByUUID = new UUIDPlayerList();
+    private UUIDPlayerList whitelistByUUID = new UUIDPlayerList();
+    private File bannedPlayersJsonFile;
+    private File opsJsonFile;
+    private File whitelistJsonFile;
 
     // CraftBukkit start
     private CraftServer cserver;
@@ -56,6 +68,12 @@ public class ServerConfigurationManager {
         this.k = minecraftserver.a("banned-ips.txt");
         this.l = minecraftserver.a("ops.txt");
         this.m = minecraftserver.a("white-list.txt");
+
+        // Poseidon - UUID-based player list JSON files
+        this.bannedPlayersJsonFile = minecraftserver.a("banned-players.json");
+        this.opsJsonFile = minecraftserver.a("ops.json");
+        this.whitelistJsonFile = minecraftserver.a("whitelist.json");
+
         int i = minecraftserver.propertyManager.getInt("view-distance", 10);
 
         // CraftBukkit - removed playermanagers
@@ -69,6 +87,10 @@ public class ServerConfigurationManager {
         this.j();
         this.l();
         this.n();
+    }
+
+    public boolean isUUIDListMode() {
+        return PoseidonConfig.getInstance().getConfigBoolean("settings.use-uuid-based-player-lists", false);
     }
 
     public void setPlayerFileData(WorldServer[] aworldserver) {
@@ -108,6 +130,11 @@ public class ServerConfigurationManager {
     }
 
     public void c(EntityPlayer entityplayer) {
+        // Poseidon - UUID reconciliation on join
+        if (isUUIDListMode() && entityplayer.playerUUID != null) {
+            reconcileUUIDEntry(entityplayer);
+        }
+
         this.players.add(entityplayer);
         //PlayerTracker.getInstance().addPlayer(entityplayer.name);
         WorldServer worldserver = this.server.getWorldServer(entityplayer.dimension);
@@ -146,6 +173,42 @@ public class ServerConfigurationManager {
 
         worldserver.addEntity(entityplayer);
         this.getPlayerManager(entityplayer.dimension).addPlayer(entityplayer);
+    }
+
+    // Poseidon - Reconcile UUID entries when a player joins
+    private void reconcileUUIDEntry(EntityPlayer entityplayer) {
+        UUID realUUID = entityplayer.playerUUID;
+        String playerName = entityplayer.name;
+        boolean changed = false;
+
+        // Check each list: if the player's name is present under a different UUID, update it
+        if (bansByUUID.containsName(playerName) && !bansByUUID.containsUUID(realUUID)) {
+            bansByUUID.removeByName(playerName);
+            bansByUUID.add(realUUID, playerName);
+            changed = true;
+        }
+        if (opsByUUID.containsName(playerName) && !opsByUUID.containsUUID(realUUID)) {
+            opsByUUID.removeByName(playerName);
+            opsByUUID.add(realUUID, playerName);
+            changed = true;
+        }
+        if (whitelistByUUID.containsName(playerName) && !whitelistByUUID.containsUUID(realUUID)) {
+            whitelistByUUID.removeByName(playerName);
+            whitelistByUUID.add(realUUID, playerName);
+            changed = true;
+        }
+
+        if (changed) {
+            a.info("[Poseidon] Reconciled UUID entries for player " + playerName + " (" + realUUID + ")");
+            this.bansByUUID.saveToJson(bannedPlayersJsonFile);
+            this.saveBansToPlainText();
+
+            this.opsByUUID.saveToJson(opsJsonFile);
+            this.saveOpsToPlainText();
+
+            this.whitelistByUUID.saveToJson(whitelistJsonFile);
+            this.saveWhitelistToPlainFile();
+        }
     }
 
     public void d(EntityPlayer entityplayer) {
@@ -201,12 +264,25 @@ public class ServerConfigurationManager {
         s1 = s1.substring(s1.indexOf("/") + 1);
         s1 = s1.substring(0, s1.indexOf(":"));
 
-        PlayerLoginEvent.Result result =
-                this.banByName.contains(s.trim().toLowerCase()) ? PlayerLoginEvent.Result.KICK_BANNED :
-                this.banByIP.contains(s1) ? PlayerLoginEvent.Result.KICK_BANNED_IP :
-                !this.isWhitelisted(s) ? PlayerLoginEvent.Result.KICK_WHITELIST :
-                this.players.size() >= this.maxPlayers ? PlayerLoginEvent.Result.KICK_FULL :
-                PlayerLoginEvent.Result.ALLOWED;
+        // Poseidon - UUID-based login checks
+        PlayerLoginEvent.Result result;
+        if (isUUIDListMode()) {
+            boolean isBanned = bansByUUID.containsUUID(entity.playerUUID) || bansByUUID.containsName(s.trim().toLowerCase());
+            boolean isIPBanned = this.banByIP.contains(s1);
+            boolean isWhitelisted = isWhitelistedInternal(s, entity.playerUUID);
+            result = isBanned ? PlayerLoginEvent.Result.KICK_BANNED :
+                    isIPBanned ? PlayerLoginEvent.Result.KICK_BANNED_IP :
+                    !isWhitelisted ? PlayerLoginEvent.Result.KICK_WHITELIST :
+                    this.players.size() >= this.maxPlayers ? PlayerLoginEvent.Result.KICK_FULL :
+                    PlayerLoginEvent.Result.ALLOWED;
+        } else {
+            result =
+                    this.banByName.contains(s.trim().toLowerCase()) ? PlayerLoginEvent.Result.KICK_BANNED :
+                    this.banByIP.contains(s1) ? PlayerLoginEvent.Result.KICK_BANNED_IP :
+                    !this.isWhitelisted(s) ? PlayerLoginEvent.Result.KICK_WHITELIST :
+                    this.players.size() >= this.maxPlayers ? PlayerLoginEvent.Result.KICK_FULL :
+                    PlayerLoginEvent.Result.ALLOWED;
+        }
 
         String kickMessage =
                 result.equals(PlayerLoginEvent.Result.KICK_BANNED) ? this.msgKickBanned :
@@ -251,7 +327,7 @@ public class ServerConfigurationManager {
 
         // CraftBukkit start
         EntityPlayer entityplayer1 = entityplayer;
-        org.bukkit.World fromWorld = entityplayer1.getBukkitEntity().getWorld();
+        World fromWorld = entityplayer1.getBukkitEntity().getWorld();
 
         if (location == null) {
             boolean isBedSpawn = false;
@@ -312,7 +388,7 @@ public class ServerConfigurationManager {
         entityplayer1.x();
         // CraftBukkit start - don't fire on respawn
         if (fromWorld != location.getWorld()) {
-            org.bukkit.event.player.PlayerChangedWorldEvent event = new org.bukkit.event.player.PlayerChangedWorldEvent((Player) entityplayer1.getBukkitEntity(), fromWorld);
+            PlayerChangedWorldEvent event = new PlayerChangedWorldEvent((Player) entityplayer1.getBukkitEntity(), fromWorld);
             Bukkit.getServer().getPluginManager().callEvent(event);
         }
         // CraftBukkit end
@@ -337,7 +413,7 @@ public class ServerConfigurationManager {
         Location fromLocation = new Location(fromWorld.getWorld(), entityplayer.locX, entityplayer.locY, entityplayer.locZ, entityplayer.yaw, entityplayer.pitch);
         Location toLocation = toWorld == null ? null : new Location(toWorld.getWorld(), (entityplayer.locX * blockRatio), entityplayer.locY, (entityplayer.locZ * blockRatio), entityplayer.yaw, entityplayer.pitch);
 
-        org.bukkit.craftbukkit.PortalTravelAgent pta = new org.bukkit.craftbukkit.PortalTravelAgent();
+        PortalTravelAgent pta = new PortalTravelAgent();
         PlayerPortalEvent event = new PlayerPortalEvent((Player) entityplayer.getBukkitEntity(), fromLocation, toLocation, pta);
         Bukkit.getServer().getPluginManager().callEvent(event);
         if (event.isCancelled() || event.getTo() == null) {
@@ -398,16 +474,40 @@ public class ServerConfigurationManager {
     }
 
     public void a(String s) {
+        this.banPlayer(s);
+    }
+
+    // Ban by name
+    public void banPlayer(String s) {
         this.banByName.add(s.toLowerCase());
-        this.h();
+
+        if (isUUIDListMode()) {
+            UUID uuid = UUIDManager.getInstance().getUUIDGraceful(s);
+            bansByUUID.add(uuid, s);
+            bansByUUID.saveToJson(bannedPlayersJsonFile);
+        }
+        this.saveBansToPlainText();
     }
 
     public void b(String s) {
+        this.unbanByName(s);
+    }
+
+    // UnBan by name - remove (pardon)
+    public void unbanByName(String s) {
         this.banByName.remove(s.toLowerCase());
-        this.h();
+        if (isUUIDListMode()) {
+            bansByUUID.removeByName(s);
+            bansByUUID.saveToJson(bannedPlayersJsonFile);
+        }
+        this.saveBansToPlainText();
     }
 
     private void g() {
+        this.loadBansFromDisk();
+    }
+
+    private void loadBansFromDisk(){
         try {
             this.banByName.clear();
             BufferedReader bufferedreader = new BufferedReader(new FileReader(this.j));
@@ -421,20 +521,32 @@ public class ServerConfigurationManager {
         } catch (Exception exception) {
             a.warning("Failed to load ban list: " + exception);
         }
+
+        // Poseidon - Load UUID ban list
+        if (isUUIDListMode()) {
+            if (bannedPlayersJsonFile.exists()) {
+                bansByUUID.loadFromJson(bannedPlayersJsonFile);
+            } else if (!this.banByName.isEmpty()) {
+                migrateToUUID(this.banByName, bansByUUID, "bans");
+                bansByUUID.saveToJson(bannedPlayersJsonFile);
+                this.saveBansToPlainText();
+            }
+        }
     }
 
     private void h() {
+        this.saveBansToPlainText();
+    }
+
+    private void saveBansToPlainText(){
         try {
-            PrintWriter printwriter = new PrintWriter(new FileWriter(this.j, false));
-            Iterator iterator = this.banByName.iterator();
-
-            while (iterator.hasNext()) {
-                String s = (String) iterator.next();
-
-                printwriter.println(s);
+            FileWriter fw = new FileWriter(this.j, false);
+            // Poseidon - if UUID mode, regenerate txt from UUID list
+            if (isUUIDListMode()) {
+                this.writeToPlainFile(bansByUUID.getNames().iterator(), fw);
+            } else {
+                this.writeToPlainFile(this.banByName.iterator(), fw);
             }
-
-            printwriter.close();
         } catch (Exception exception) {
             a.warning("Failed to save ban list: " + exception);
         }
@@ -468,24 +580,35 @@ public class ServerConfigurationManager {
 
     private void j() {
         try {
-            PrintWriter printwriter = new PrintWriter(new FileWriter(this.k, false));
-            Iterator iterator = this.banByIP.iterator();
-
-            while (iterator.hasNext()) {
-                String s = (String) iterator.next();
-
-                printwriter.println(s);
-            }
-
-            printwriter.close();
+            this.writeToPlainFile(this.banByIP.iterator(), new FileWriter(this.k, false));
         } catch (Exception exception) {
             a.warning("Failed to save ip ban list: " + exception);
         }
     }
 
+    private void writeToPlainFile(Iterator i, FileWriter fw) {
+        PrintWriter printwriter = new PrintWriter(fw);
+        while (i.hasNext()) {
+            printwriter.println(i.next().toString());
+        }
+        printwriter.close();
+    }
+
+
     public void e(String s) {
+        this.addOp(s);
+    }
+
+    // Op - add
+    public void addOp(String s) {
         this.h.add(s.toLowerCase());
-        this.l();
+        // Poseidon - also add to UUID list
+        if (isUUIDListMode()) {
+            UUID uuid = UUIDManager.getInstance().getUUIDGraceful(s);
+            opsByUUID.add(uuid, s);
+            opsByUUID.saveToJson(opsJsonFile);
+        }
+        this.saveOpsToPlainText();
 
         // Craftbukkit start
         Player player = server.server.getPlayer(s);
@@ -496,8 +619,18 @@ public class ServerConfigurationManager {
     }
 
     public void f(String s) {
+        this.removeOp(s);
+    }
+
+    // Op - remove (deop)
+    public void removeOp(String s){
         this.h.remove(s.toLowerCase());
-        this.l();
+        // Poseidon - also remove from UUID list
+        if (isUUIDListMode()) {
+            opsByUUID.removeByName(s);
+            opsByUUID.saveToJson(opsJsonFile);
+        }
+        this.saveOpsToPlainText();
 
         // Craftbukkit start
         Player player = server.server.getPlayer(s);
@@ -508,6 +641,11 @@ public class ServerConfigurationManager {
     }
 
     private void k() {
+        this.loadOpFromDisk();
+    }
+
+    // Load ops from txt
+    private void loadOpFromDisk(){
         try {
             this.h.clear();
             BufferedReader bufferedreader = new BufferedReader(new FileReader(this.l));
@@ -522,20 +660,34 @@ public class ServerConfigurationManager {
             // CraftBukkit - corrected text
             a.warning("Failed to load ops: " + exception);
         }
+
+        // Poseidon - Load UUID ops list
+        if (isUUIDListMode()) {
+            if (opsJsonFile.exists()) {
+                opsByUUID.loadFromJson(opsJsonFile);
+            } else if (!this.h.isEmpty()) {
+                migrateToUUID(this.h, opsByUUID, "ops");
+                opsByUUID.saveToJson(opsJsonFile);
+                this.saveOpsToPlainText();
+            }
+        }
     }
 
+
     private void l() {
+        this.saveOpsToPlainText();
+    }
+
+    // Save ops to txt
+    private void saveOpsToPlainText(){
         try {
-            PrintWriter printwriter = new PrintWriter(new FileWriter(this.l, false));
-            Iterator iterator = this.h.iterator();
-
-            while (iterator.hasNext()) {
-                String s = (String) iterator.next();
-
-                printwriter.println(s);
+            FileWriter fw = new FileWriter(this.l, false);
+            // Poseidon - if UUID mode, regenerate txt from UUID list
+            if (isUUIDListMode()) {
+                this.writeToPlainFile(opsByUUID.getNames().iterator(), fw);
+            } else {
+                this.writeToPlainFile(this.h.iterator(), fw);
             }
-
-            printwriter.close();
         } catch (Exception exception) {
             // CraftBukkit - corrected text
             a.warning("Failed to save ops: " + exception);
@@ -543,6 +695,10 @@ public class ServerConfigurationManager {
     }
 
     private void m() {
+        this.loadWhitelistFromDisk();
+    }
+
+    private void loadWhitelistFromDisk(){
         try {
             this.i.clear();
             BufferedReader bufferedreader = new BufferedReader(new FileReader(this.m));
@@ -556,32 +712,90 @@ public class ServerConfigurationManager {
         } catch (Exception exception) {
             a.warning("Failed to load white-list: " + exception);
         }
+
+        // Poseidon - Load UUID whitelist
+        if (isUUIDListMode()) {
+            if (whitelistJsonFile.exists()) {
+                whitelistByUUID.loadFromJson(whitelistJsonFile);
+            } else if (!this.i.isEmpty()) {
+                migrateToUUID(this.i, whitelistByUUID, "whitelist");
+                whitelistByUUID.saveToJson(whitelistJsonFile);
+                this.saveWhitelistToPlainFile();
+            }
+        }
     }
 
+    // Save whitelist to txt
     private void n() {
+        this.saveWhitelistToPlainFile();
+    }
+
+    private void saveWhitelistToPlainFile(){
         try {
-            PrintWriter printwriter = new PrintWriter(new FileWriter(this.m, false));
-            Iterator iterator = this.i.iterator();
-
-            while (iterator.hasNext()) {
-                String s = (String) iterator.next();
-
-                printwriter.println(s);
+            FileWriter fw = new FileWriter(this.m, false);
+            // Poseidon - if UUID mode, regenerate txt from UUID list
+            if (isUUIDListMode()) {
+                this.writeToPlainFile(whitelistByUUID.getNames().iterator(), fw);
+            } else {
+                this.writeToPlainFile(this.i.iterator(), fw);
             }
-
-            printwriter.close();
         } catch (Exception exception) {
             a.warning("Failed to save white-list: " + exception);
         }
     }
 
+    // Poseidon - migrate txt entries to UUID list
+    private void migrateToUUID(Set<String> txtSet, UUIDPlayerList uuidList, String listName) {
+        a.info("[Poseidon] Migrating " + listName + " to UUID-based storage (" + txtSet.size() + " entries)...");
+        for (Object entry : txtSet) {
+            String name = (String) entry;
+            UUID uuid = UUIDManager.getInstance().getUUIDGraceful(name);
+            uuidList.add(uuid, name);
+        }
+        a.info("[Poseidon] Migration of " + listName + " complete.");
+    }
+
     public boolean isWhitelisted(String s) {
+        if (isUUIDListMode()) {
+            return isWhitelistedInternal(s, null);
+        }
         s = s.trim().toLowerCase();
         return !this.o || this.h.contains(s) || this.i.contains(s);
     }
 
+    // Poseidon - internal whitelist check supporting both name and UUID
+    private boolean isWhitelistedInternal(String name, UUID uuid) {
+        if (!this.o) return true;
+        String lowerName = name.trim().toLowerCase();
+        // Check ops and whitelist by name
+        if (opsByUUID.containsName(lowerName) || whitelistByUUID.containsName(lowerName)) return true;
+        // Check by UUID if provided
+        return uuid != null && (opsByUUID.containsUUID(uuid) || whitelistByUUID.containsUUID(uuid));
+    }
+
+    public boolean isWhitelistedByUUID(UUID uuid) {
+        if (!this.o) return true;
+        return opsByUUID.containsUUID(uuid) || whitelistByUUID.containsUUID(uuid);
+    }
+
     public boolean isOp(String s) {
+        if (isUUIDListMode()) {
+            return opsByUUID.containsName(s.trim().toLowerCase());
+        }
         return this.h.contains(s.trim().toLowerCase());
+    }
+
+    // Poseidon - check if banned by name (dispatches to UUID if enabled)
+    public boolean isBanned(String s) {
+        if (isUUIDListMode()) {
+            return bansByUUID.containsName(s.trim().toLowerCase());
+        }
+        return this.banByName.contains(s.trim().toLowerCase());
+    }
+
+    // Poseidon - check if banned by UUID
+    public boolean isBannedByUUID(UUID uuid) {
+        return bansByUUID.containsUUID(uuid);
     }
 
     public EntityPlayer i(String s) {
@@ -657,16 +871,39 @@ public class ServerConfigurationManager {
     }
 
     public void k(String s) {
-        this.i.add(s);
-        this.n();
+        this.addToWhitelist(s);
     }
 
+    public void addToWhitelist(String s) {
+        this.i.add(s);
+        // Poseidon - also add to UUID list
+        if (isUUIDListMode()) {
+            UUID uuid = UUIDManager.getInstance().getUUIDGraceful(s);
+            whitelistByUUID.add(uuid, s);
+            whitelistByUUID.saveToJson(whitelistJsonFile);
+        }
+        this.saveWhitelistToPlainFile();
+    }
+
+    // Whitelist - remove
     public void l(String s) {
         this.i.remove(s);
-        this.n();
+        // Poseidon - also remove from UUID list
+        if (isUUIDListMode()) {
+            whitelistByUUID.removeByName(s);
+            whitelistByUUID.saveToJson(whitelistJsonFile);
+        }
+        this.saveWhitelistToPlainFile();
     }
 
     public Set e() {
+        return this.getWhitelistedPlayers();
+    }
+
+    public Set getWhitelistedPlayers() {
+        if (isUUIDListMode()) {
+            return whitelistByUUID.getNames();
+        }
         return this.i;
     }
 
@@ -684,5 +921,18 @@ public class ServerConfigurationManager {
     public void updateClient(EntityPlayer entityplayer) {
         entityplayer.updateInventory(entityplayer.defaultContainer);
         entityplayer.C();
+    }
+
+    // Poseidon - UUID list getters for CraftServer
+    public UUIDPlayerList getBansByUUID() {
+        return bansByUUID;
+    }
+
+    public UUIDPlayerList getOpsByUUID() {
+        return opsByUUID;
+    }
+
+    public UUIDPlayerList getWhitelistByUUID() {
+        return whitelistByUUID;
     }
 }

--- a/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftOfflinePlayer.java
@@ -39,7 +39,7 @@ public class CraftOfflinePlayer implements OfflinePlayer {
     }
 
     public boolean isBanned() {
-        return server.getHandle().banByName.contains(name.toLowerCase());
+        return server.getHandle().isBanned(name);
     }
 
     public void setBanned(boolean value) {
@@ -51,7 +51,7 @@ public class CraftOfflinePlayer implements OfflinePlayer {
     }
 
     public boolean isWhitelisted() {
-        return server.getHandle().e().contains(name.toLowerCase());
+        return server.getHandle().isWhitelisted(name);
     }
 
     public void setWhitelisted(boolean value) {

--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
@@ -5,10 +5,8 @@ import com.avaje.ebean.config.ServerConfig;
 import com.avaje.ebean.config.dbplatform.SQLitePlatform;
 import com.avaje.ebeaninternal.server.lib.sql.TransactionIsolation;
 import com.legacyminecraft.poseidon.Poseidon;
-import com.legacyminecraft.poseidon.PoseidonConfig;
-import com.legacyminecraft.poseidon.PoseidonPlugin;
 import com.legacyminecraft.poseidon.PoseidonServer;
-import com.legacyminecraft.poseidon.utility.PoseidonVersionChecker;
+import com.legacyminecraft.poseidon.util.UUIDPlayerList;
 import jline.ConsoleReader;
 import net.minecraft.server.*;
 import org.bukkit.Bukkit;
@@ -833,8 +831,14 @@ public final class CraftServer implements Server {
     public Set<OfflinePlayer> getBannedPlayers() {
         Set<OfflinePlayer> result = new HashSet<OfflinePlayer>();
 
-        for (Object name : server.banByName) {
-            result.add(getOfflinePlayer((String) name));
+        if (server.isUUIDListMode()) {
+            for (UUIDPlayerList.PlayerListEntry entry : server.getBansByUUID().entries()) {
+                result.add(getOfflinePlayer(entry.name));
+            }
+        } else {
+            for (Object name : server.banByName) {
+                result.add(getOfflinePlayer((String) name));
+            }
         }
 
         return result;
@@ -849,8 +853,14 @@ public final class CraftServer implements Server {
     public Set<OfflinePlayer> getWhitelistedPlayers() {
         Set<OfflinePlayer> result = new HashSet<OfflinePlayer>();
 
-        for (Object name : server.e()) {
-            result.add(getOfflinePlayer((String) name));
+        if (server.isUUIDListMode()) {
+            for (UUIDPlayerList.PlayerListEntry entry : server.getWhitelistByUUID().entries()) {
+                result.add(getOfflinePlayer(entry.name));
+            }
+        } else {
+            for (Object name : server.e()) {
+                result.add(getOfflinePlayer((String) name));
+            }
         }
 
         return result;

--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
@@ -378,7 +378,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     }
 
     public boolean isBanned() {
-        return server.getHandle().banByName.contains(getName().toLowerCase());
+        if (server.getHandle().isUUIDListMode()) {
+            return server.getHandle().isBannedByUUID(getHandle().playerUUID) || server.getHandle().isBanned(getName());
+        }
+        return server.getHandle().isBanned(getName());
     }
 
     public void setBanned(boolean value) {
@@ -390,7 +393,10 @@ public class CraftPlayer extends CraftHumanEntity implements Player {
     }
 
     public boolean isWhitelisted() {
-        return server.getHandle().e().contains(getName().toLowerCase());
+        if (server.getHandle().isUUIDListMode()) {
+            return server.getHandle().isWhitelistedByUUID(getHandle().playerUUID);
+        }
+        return server.getHandle().isWhitelisted(getName());
     }
 
     public void setWhitelisted(boolean value) {


### PR DESCRIPTION

## Description

This PR integrates PoseidonUUIDs with standard validations for ban/op/whitelist. Currently commands are not set to support direct use of UUID.


## Motivation & Context

In order to improve security and among other things reduce ban avoidance by name changing.

## Type of Change

Please tick all that apply:

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ⚡ Performance improvement
- [x] 🧩 New feature (non-breaking)
- [x] 🔧 Refactor / cleanup (no functional changes)
- [ ] 🔥 Crash / exploit fix
- [ ] 📚 Documentation update
- [ ] ❗ Breaking change (may affect plugins or server behavior)

## Testing Performed

Tested ban/pardon, op/deop, whitelisting ops in general to look for proper storing and validation as well as no crash or error.


## Compatibility Considerations

The code is designed to keep both models working and reconcile from standard text/name based approach to the new that includes UUID.

## Additional Notes

Some function wrapping and comments were added to improve readability.


