### PR TITLE
feat: Add local sample setup for Prometheus + Grafana monitoring

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -235,3 +235,7 @@ hs_err_pid*
 
 # Don't need dependecy reduced pom
 dependency-reduced-pom.xml
+
+
+# Monitoring local test setup
+monitoring/poseidon-data/

--- a/README.md
+++ b/README.md
@@ -90,6 +90,15 @@ mvn clean package
 
 You should now have a runnable JAR inside the /target folder!
 
+## Monitoring (Prometheus + Grafana)
+
+Project Poseidon includes a built-in Prometheus endpoint for Java 8 deployments.
+
+- Default endpoint: `http://<server-host>:9464/metrics`
+- Config keys (in `server.properties`): `prometheus.enabled`, `prometheus.host`, `prometheus.port`
+- Local Prometheus/Grafana stack: see [monitoring/README.md](monitoring/README.md)
+- Local smoke test: `./monitoring/scripts/smoke-test.sh`
+
 ## Regarding the DMCA of CraftBukkit in 2014
 The contributor Wolverness who first contributed on CraftBukkit in February 2012 issued a DMCA against CraftBukkit and other major forks of CraftBukkit.
 This project is based on the following commits:

--- a/monitoring/README.md
+++ b/monitoring/README.md
@@ -1,0 +1,102 @@
+# Project Poseidon Monitoring
+
+This is a local setup for testing monitoring of Poseidon server.
+
+Server exposes Prometheus metrics directly from the server process at:
+
+- `http://<server-host>:9464/metrics` (default)
+
+The endpoint is controlled by `server.properties`:
+
+- `prometheus.enabled=true`
+- `prometheus.host=0.0.0.0`
+- `prometheus.port=9464`
+
+## Quick Start
+
+From repository root:
+
+```bash
+mvn clean package
+cd monitoring
+docker compose up -d
+docker compose exec poseidon sh
+```
+
+Container data files are stored at:
+
+- `monitoring/poseidon-data`
+
+## Run Poseidon In Java 8 Container
+
+Build the server jar first from repository root:
+
+```bash
+mvn clean package
+```
+
+Then start Poseidon from `monitoring/`:
+
+```bash
+docker compose up -d poseidon
+docker compose logs -f poseidon
+```
+
+Recommended mode is detached (`-d`) so Prometheus/Grafana and the server keep running in the background.
+
+## Open A Shell In The Poseidon Container
+
+From `monitoring/`:
+
+```bash
+docker compose exec poseidon sh
+```
+
+Or by container name:
+
+```bash
+docker exec -it poseidon-server sh
+```
+
+Container details:
+
+- Java runtime: `eclipse-temurin:8-jre`
+- JAR mount: `../target -> /opt/poseidon/target` (read-only)
+- Server data directory: `monitoring/poseidon-data`
+- Exposed ports: `25565` (MC), `9464` (Prometheus)
+- If `server.properties` is missing in `poseidon-data/`, the startup script creates one with Prometheus enabled on `0.0.0.0:9464`
+
+Optional overrides:
+
+- Force specific JAR from `target/`:
+  `POSEIDON_JAR=<JAR_NAME>.jar docker compose up -d poseidon`
+- Set JVM heap:
+  `JAVA_XMS=1g JAVA_XMX=2g docker compose up -d poseidon`
+- Add extra JVM options:
+  `JAVA_OPTS="-XX:+UseG1GC" docker compose up -d poseidon`
+
+## Local Monitoring Stack (Prometheus + Grafana)
+
+From `monitoring/`:
+
+```bash
+docker compose up -d prometheus grafana
+```
+
+- Prometheus: `http://localhost:9090`
+- Grafana: `http://localhost:3000` (Credentials: `admin` / `admin`)
+
+Open Included dashboard `Project Poseidon - Server Overview`.
+Left sidebar `Dashboards` then navigation the dashboard tree or directly with url `http://localhost:3000/d/poseidon-overview/project-poseidon-server-overview` 
+
+## Prometheus
+
+Prometheus is configured to try scrape both locally (docker network specific):
+
+1. `poseidon:9464` (docker compose network)
+2. Host fallbacks: `host.docker.internal:9464`, `172.17.0.1:9464`
+
+You can check Prometheus -> Poseidon connection by accessing the targets. Either by (top menu) `Status > Targets` or 
+directly to `http://localhost:9090/targets`. In Prometheus landing page you can also run one of the following expressions,
+   - `up{job="project-poseidon"}`
+   - `poseidon_server_up`

--- a/monitoring/docker-compose.yml
+++ b/monitoring/docker-compose.yml
@@ -1,0 +1,53 @@
+services:
+  poseidon:
+    image: eclipse-temurin:8-jre
+    container_name: poseidon-server
+    working_dir: /opt/poseidon/data
+    command: ["/bin/sh", "/opt/poseidon/scripts/run-poseidon.sh"]
+    ports:
+      - "25565:25565"
+      - "9464:9464"
+    volumes:
+      - ../target:/opt/poseidon/target:ro
+      - ./scripts:/opt/poseidon/scripts:ro
+      - ./poseidon-data:/opt/poseidon/data
+    restart: unless-stopped
+
+  prometheus:
+    image: prom/prometheus:v2.54.1
+    container_name: poseidon-prometheus
+    depends_on:
+      - poseidon
+    command:
+      - --config.file=/etc/prometheus/prometheus.yml
+      - --storage.tsdb.path=/prometheus
+      - --web.enable-lifecycle
+    ports:
+      - "9090:9090"
+    volumes:
+      - ./prometheus/prometheus.yml:/etc/prometheus/prometheus.yml:ro
+      - prometheus-data:/prometheus
+    extra_hosts:
+      host.docker.internal: host-gateway
+    restart: unless-stopped
+
+  grafana:
+    image: grafana/grafana:11.2.2
+    container_name: poseidon-grafana
+    depends_on:
+      - prometheus
+    environment:
+      - GF_SECURITY_ADMIN_USER=admin
+      - GF_SECURITY_ADMIN_PASSWORD=admin
+      - GF_USERS_ALLOW_SIGN_UP=false
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./grafana/provisioning:/etc/grafana/provisioning:ro
+      - ./grafana/dashboards:/var/lib/grafana/dashboards:ro
+      - grafana-data:/var/lib/grafana
+    restart: unless-stopped
+
+volumes:
+  prometheus-data:
+  grafana-data:

--- a/monitoring/grafana/dashboards/project-poseidon-overview.json
+++ b/monitoring/grafana/dashboards/project-poseidon-overview.json
@@ -1,0 +1,758 @@
+{
+  "annotations": {
+    "list": [
+      {
+        "builtIn": 1,
+        "datasource": {
+          "type": "grafana",
+          "uid": "-- Grafana --"
+        },
+        "enable": true,
+        "hide": true,
+        "iconColor": "rgba(0, 211, 255, 1)",
+        "name": "Annotations & Alerts",
+        "type": "dashboard"
+      }
+    ]
+  },
+  "editable": true,
+  "fiscalYearStartMonth": 0,
+  "graphTooltip": 0,
+  "id": null,
+  "links": [],
+  "liveNow": false,
+  "panels": [
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "green",
+                "value": 1
+              }
+            ]
+          },
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 0,
+        "y": 0
+      },
+      "id": 1,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "poseidon_server_up",
+          "legendFormat": "up",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Server Up",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "red",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 15
+              },
+              {
+                "color": "green",
+                "value": 19
+              }
+            ]
+          },
+          "unit": "none",
+          "decimals": 2,
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 4,
+        "y": 0
+      },
+      "id": 2,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "poseidon_tps",
+          "legendFormat": "tps",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "TPS (1m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 30
+              },
+              {
+                "color": "red",
+                "value": 50
+              }
+            ]
+          },
+          "unit": "ms",
+          "decimals": 2,
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 8,
+        "y": 0
+      },
+      "id": 3,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "poseidon_tick_duration_millis_avg_1m",
+          "legendFormat": "avg_ms",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Tick Avg (1m)",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 12,
+        "y": 0
+      },
+      "id": 4,
+      "options": {
+        "colorMode": "background",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "poseidon_players_online",
+          "legendFormat": "online",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Players Online",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "thresholds"
+          },
+          "thresholds": {
+            "mode": "absolute",
+            "steps": [
+              {
+                "color": "green",
+                "value": null
+              },
+              {
+                "color": "orange",
+                "value": 70
+              },
+              {
+                "color": "red",
+                "value": 90
+              }
+            ]
+          },
+          "unit": "percent",
+          "decimals": 1,
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 16,
+        "y": 0
+      },
+      "id": 5,
+      "options": {
+        "colorMode": "value",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "100 * poseidon_players_online / clamp_min(poseidon_players_max, 1)",
+          "legendFormat": "capacity",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Player Capacity",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 4,
+        "w": 4,
+        "x": 20,
+        "y": 0
+      },
+      "id": 6,
+      "options": {
+        "colorMode": "none",
+        "graphMode": "none",
+        "justifyMode": "auto",
+        "orientation": "auto",
+        "reduceOptions": {
+          "calcs": [
+            "lastNotNull"
+          ],
+          "fields": "",
+          "values": false
+        },
+        "textMode": "auto"
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "poseidon_worlds_loaded",
+          "legendFormat": "worlds",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Worlds Loaded",
+      "type": "stat"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ms",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 4
+      },
+      "id": 7,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "poseidon_tick_duration_millis_last",
+          "legendFormat": "last",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "poseidon_tick_duration_millis_avg_1m",
+          "legendFormat": "avg_1m",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "histogram_quantile(0.95, sum(rate(poseidon_tick_duration_seconds_bucket[5m])) by (le)) * 1000",
+          "legendFormat": "p95_5m",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Tick Duration",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "ops",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 4
+      },
+      "id": 8,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(poseidon_slow_ticks_total[1m])",
+          "legendFormat": "slow_ticks_per_second",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "Slow Tick Rate (>50ms)",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 0,
+        "y": 12
+      },
+      "id": 9,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jvm_memory_bytes_used{area=~\"heap|nonheap\"}",
+          "legendFormat": "{{area}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Memory Used",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "none",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 8,
+        "y": 12
+      },
+      "id": 10,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jvm_threads_state",
+          "legendFormat": "{{state}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "JVM Threads by State",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "bytes",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 8,
+        "x": 16,
+        "y": 12
+      },
+      "id": 11,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "process_resident_memory_bytes",
+          "legendFormat": "resident",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "process_virtual_memory_bytes",
+          "legendFormat": "virtual",
+          "range": true,
+          "refId": "B"
+        }
+      ],
+      "title": "Process Memory",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "s",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 0,
+        "y": 20
+      },
+      "id": 12,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "rate(jvm_gc_collection_seconds_sum[5m])",
+          "legendFormat": "{{gc}}",
+          "range": true,
+          "refId": "A"
+        }
+      ],
+      "title": "GC Time Rate",
+      "type": "timeseries"
+    },
+    {
+      "datasource": {
+        "type": "prometheus",
+        "uid": "prometheus"
+      },
+      "fieldConfig": {
+        "defaults": {
+          "color": {
+            "mode": "palette-classic"
+          },
+          "unit": "short",
+          "mappings": []
+        },
+        "overrides": []
+      },
+      "gridPos": {
+        "h": 8,
+        "w": 12,
+        "x": 12,
+        "y": 20
+      },
+      "id": 13,
+      "options": {
+        "legend": {
+          "calcs": [],
+          "displayMode": "table",
+          "placement": "bottom",
+          "showLegend": true
+        },
+        "tooltip": {
+          "mode": "single",
+          "sort": "none"
+        }
+      },
+      "targets": [
+        {
+          "editorMode": "code",
+          "expr": "jvm_threads_current",
+          "legendFormat": "current",
+          "range": true,
+          "refId": "A"
+        },
+        {
+          "editorMode": "code",
+          "expr": "jvm_threads_daemon",
+          "legendFormat": "daemon",
+          "range": true,
+          "refId": "B"
+        },
+        {
+          "editorMode": "code",
+          "expr": "jvm_threads_peak",
+          "legendFormat": "peak",
+          "range": true,
+          "refId": "C"
+        }
+      ],
+      "title": "Thread Counters",
+      "type": "timeseries"
+    }
+  ],
+  "refresh": "5s",
+  "schemaVersion": 39,
+  "style": "dark",
+  "tags": [
+    "minecraft",
+    "poseidon",
+    "beta-1.7.3"
+  ],
+  "templating": {
+    "list": []
+  },
+  "time": {
+    "from": "now-15m",
+    "to": "now"
+  },
+  "timepicker": {},
+  "timezone": "",
+  "title": "Project Poseidon - Server Overview",
+  "uid": "poseidon-overview",
+  "version": 2,
+  "weekStart": ""
+}

--- a/monitoring/grafana/provisioning/dashboards/poseidon.yml
+++ b/monitoring/grafana/provisioning/dashboards/poseidon.yml
@@ -7,6 +7,6 @@ providers:
     type: file
     disableDeletion: false
     editable: true
-    updateIntervalSeconds: 10
+    updateIntervalSeconds: 10 # This can and probably should be changed to prevent people from leaving the dashboard open and continously querying grafana server
     options:
       path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/dashboards/poseidon.yml
+++ b/monitoring/grafana/provisioning/dashboards/poseidon.yml
@@ -1,0 +1,12 @@
+apiVersion: 1
+
+providers:
+  - name: Project-Poseidon
+    orgId: 1
+    folder: Project Poseidon
+    type: file
+    disableDeletion: false
+    editable: true
+    updateIntervalSeconds: 10
+    options:
+      path: /var/lib/grafana/dashboards

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -1,0 +1,10 @@
+apiVersion: 1
+
+datasources:
+  - name: Prometheus
+    uid: prometheus
+    type: prometheus
+    access: proxy
+    url: http://prometheus:9090
+    isDefault: true
+    editable: true

--- a/monitoring/grafana/provisioning/datasources/prometheus.yml
+++ b/monitoring/grafana/provisioning/datasources/prometheus.yml
@@ -7,4 +7,4 @@ datasources:
     access: proxy
     url: http://prometheus:9090
     isDefault: true
-    editable: true
+    editable: true # We can probably set this to false in prod to prevent mishaps

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,4 +1,4 @@
-global:
+global: # Locally these values are fine but we tipically increase this to 30s if it get's heavy on the server
   scrape_interval: 5s
   evaluation_interval: 5s
 

--- a/monitoring/prometheus/prometheus.yml
+++ b/monitoring/prometheus/prometheus.yml
@@ -1,0 +1,19 @@
+global:
+  scrape_interval: 5s
+  evaluation_interval: 5s
+
+scrape_configs:
+  - job_name: project-poseidon
+    metrics_path: /metrics
+    static_configs:
+      - targets:
+          - poseidon:9464
+        labels:
+          source: docker-compose
+          server: local-beta-server
+      - targets:
+          - host.docker.internal:9464
+          - 172.17.0.1:9464
+        labels:
+          source: host-network-fallback
+          server: local-beta-server

--- a/monitoring/scripts/run-poseidon.sh
+++ b/monitoring/scripts/run-poseidon.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+set -eu
+
+TARGET_DIR="/opt/poseidon/target"
+DATA_DIR="/opt/poseidon/data"
+
+cd "${DATA_DIR}"
+
+if [ -n "${POSEIDON_JAR:-}" ]; then
+  jar_file="${TARGET_DIR}/${POSEIDON_JAR}"
+else
+  jar_file="$(ls -1 "${TARGET_DIR}"/*.jar 2>/dev/null | grep -Ev '/original-|sources|javadoc' | head -n 1 || true)"
+fi
+
+if [ -z "${jar_file}" ] || [ ! -f "${jar_file}" ]; then
+  echo "No runnable Poseidon jar found in ${TARGET_DIR}" >&2
+  echo "Build it first from repo root: mvn clean package" >&2
+  echo "Then start compose from monitoring/: docker compose up -d poseidon" >&2
+  exit 1
+fi
+
+if [ ! -f "server.properties" ]; then
+  cat > server.properties <<'PROPS'
+server-ip=0.0.0.0
+server-port=25565
+prometheus.enabled=true
+prometheus.host=0.0.0.0
+prometheus.port=9464
+PROPS
+fi
+
+echo "Starting Poseidon from ${jar_file}"
+
+JAVA_XMS="${JAVA_XMS:-512m}"
+JAVA_XMX="${JAVA_XMX:-1024m}"
+JAVA_OPTS="${JAVA_OPTS:-}"
+
+# JAVA_OPTS is intentionally unquoted to allow multiple JVM flags.
+exec java -Xms"${JAVA_XMS}" -Xmx"${JAVA_XMX}" ${JAVA_OPTS} -jar "${jar_file}" --nogui

--- a/pom.xml
+++ b/pom.xml
@@ -167,6 +167,22 @@
             <version>2.9.0</version>
         </dependency>
 
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_hotspot</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+        <dependency>
+            <groupId>io.prometheus</groupId>
+            <artifactId>simpleclient_httpserver</artifactId>
+            <version>0.16.0</version>
+        </dependency>
+
     </dependencies>
     <!-- This builds a completely 'ready to start' jar with all dependencies inside -->
     <build>

--- a/src/main/java/com/legacyminecraft/poseidon/monitoring/PrometheusMonitoringService.java
+++ b/src/main/java/com/legacyminecraft/poseidon/monitoring/PrometheusMonitoringService.java
@@ -1,0 +1,223 @@
+package com.legacyminecraft.poseidon.monitoring;
+
+import io.prometheus.client.Counter;
+import io.prometheus.client.CollectorRegistry;
+import io.prometheus.client.Gauge;
+import io.prometheus.client.Histogram;
+import io.prometheus.client.exporter.HTTPServer;
+import io.prometheus.client.hotspot.DefaultExports;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.ServerConfigurationManager;
+
+import java.io.IOException;
+import java.net.InetSocketAddress;
+import java.util.ArrayDeque;
+import java.util.Deque;
+import java.util.LinkedList;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+
+public final class PrometheusMonitoringService {
+    private static final Logger LOGGER = Logger.getLogger("Minecraft");
+    private static final int TPS_WINDOW_SECONDS = 60;
+    private static final int TICKS_PER_SECOND = 20;
+    private static boolean defaultExportsInitialized = false;
+
+    private final MinecraftServer server;
+    private final String host;
+    private final int port;
+
+    private final Gauge poseidonServerUp = Gauge.build()
+            .name("poseidon_server_up")
+            .help("Poseidon server process up status (1=up, 0=down).")
+            .register();
+    private final Gauge poseidonPlayersOnline = Gauge.build()
+            .name("poseidon_players_online")
+            .help("Current number of online players.")
+            .register();
+    private final Gauge poseidonPlayersMax = Gauge.build()
+            .name("poseidon_players_max")
+            .help("Configured maximum players.")
+            .register();
+    private final Gauge poseidonWorldsLoaded = Gauge.build()
+            .name("poseidon_worlds_loaded")
+            .help("Current number of loaded worlds.")
+            .register();
+    private final Gauge poseidonTps = Gauge.build()
+            .name("poseidon_tps")
+            .help("Average TPS over the latest one-minute window.")
+            .register();
+    private final Gauge poseidonTickDurationMillisLast = Gauge.build()
+            .name("poseidon_tick_duration_millis_last")
+            .help("Duration of the most recent server tick in milliseconds.")
+            .register();
+    private final Gauge poseidonTickDurationMillisAvg1m = Gauge.build()
+            .name("poseidon_tick_duration_millis_avg_1m")
+            .help("Average tick duration over the latest minute in milliseconds.")
+            .register();
+    private final Histogram poseidonTickDurationSeconds = Histogram.build()
+            .name("poseidon_tick_duration_seconds")
+            .help("Tick duration distribution in seconds.")
+            .buckets(0.01D, 0.02D, 0.03D, 0.05D, 0.1D, 0.2D, 0.5D, 1.0D)
+            .register();
+    private final Counter poseidonSlowTicks = Counter.build()
+            .name("poseidon_slow_ticks_total")
+            .help("Number of ticks that exceeded 50ms.")
+            .register();
+
+    // Basic aliases for dashboards built around older Bukkit exporter names.
+    private final Gauge mcPlayersOnlineTotal = Gauge.build()
+            .name("mc_players_online_total")
+            .help("Alias for current online player count.")
+            .register();
+    private final Gauge mcTps = Gauge.build()
+            .name("mc_tps")
+            .help("Alias for average TPS over the latest one-minute window.")
+            .register();
+    private final Gauge mcTickDurationAverage = Gauge.build()
+            .name("mc_tick_duration_average")
+            .help("Alias for average tick duration over the latest minute in milliseconds.")
+            .register();
+
+    private final Deque<Long> recentTickDurationsNanos = new ArrayDeque<Long>();
+    private final int recentTickWindowSize = TPS_WINDOW_SECONDS * TICKS_PER_SECOND;
+    private long recentTickDurationsTotalNanos = 0L;
+
+    private HTTPServer httpServer;
+
+    private PrometheusMonitoringService(MinecraftServer server, String host, int port) {
+        this.server = server;
+        this.host = host;
+        this.port = port;
+    }
+
+    public static PrometheusMonitoringService startIfEnabled(MinecraftServer server) {
+        if (server == null || server.propertyManager == null) {
+            return null;
+        }
+
+        boolean enabled = server.propertyManager.getBoolean("prometheus.enabled", true);
+        if (!enabled) {
+            LOGGER.info("[Prometheus] Metrics exporter disabled via server.properties (prometheus.enabled=false).");
+            return null;
+        }
+
+        String host = server.propertyManager.getString("prometheus.host", "0.0.0.0");
+        int port = server.propertyManager.getInt("prometheus.port", 9464);
+        PrometheusMonitoringService service = new PrometheusMonitoringService(server, host, port);
+
+        try {
+            service.start();
+            LOGGER.info("[Prometheus] Metrics exporter started on http://" + host + ":" + port + "/metrics");
+            return service;
+        } catch (Throwable throwable) {
+            LOGGER.log(Level.WARNING, "[Prometheus] Failed to start metrics exporter. Server will continue without Prometheus metrics.", throwable);
+            service.stop();
+            return null;
+        }
+    }
+
+    private static synchronized void initializeDefaultExportsIfNeeded() {
+        if (!defaultExportsInitialized) {
+            DefaultExports.initialize();
+            defaultExportsInitialized = true;
+        }
+    }
+
+    private void start() throws IOException {
+        initializeDefaultExportsIfNeeded();
+        this.httpServer = new HTTPServer(new InetSocketAddress(this.host, this.port), CollectorRegistry.defaultRegistry, true);
+        this.poseidonServerUp.set(1D);
+        this.poseidonTickDurationMillisLast.set(0D);
+        this.poseidonTickDurationMillisAvg1m.set(0D);
+        this.poseidonTps.set(20D);
+        this.mcTps.set(20D);
+    }
+
+    public void stop() {
+        this.poseidonServerUp.set(0D);
+        if (this.httpServer != null) {
+            this.httpServer.stop();
+            this.httpServer = null;
+        }
+    }
+
+    public void onTickComplete(long tickDurationNanos) {
+        if (tickDurationNanos < 0L) {
+            return;
+        }
+
+        double tickDurationMillis = tickDurationNanos / 1_000_000.0D;
+        this.poseidonTickDurationMillisLast.set(tickDurationMillis);
+        this.poseidonTickDurationSeconds.observe(tickDurationNanos / 1_000_000_000.0D);
+
+        if (tickDurationNanos > 50_000_000L) {
+            this.poseidonSlowTicks.inc();
+        }
+
+        double averageTickDurationMillis = updateRecentTickAverage(tickDurationNanos);
+        this.poseidonTickDurationMillisAvg1m.set(averageTickDurationMillis);
+        this.mcTickDurationAverage.set(averageTickDurationMillis);
+
+        int onlinePlayers = 0;
+        int maxPlayers = 0;
+        ServerConfigurationManager configurationManager = this.server.serverConfigurationManager;
+        if (configurationManager != null) {
+            onlinePlayers = configurationManager.players.size();
+            maxPlayers = configurationManager.maxPlayers;
+        }
+
+        this.poseidonPlayersOnline.set(onlinePlayers);
+        this.poseidonPlayersMax.set(maxPlayers);
+        this.poseidonWorldsLoaded.set(this.server.worlds == null ? 0 : this.server.worlds.size());
+        this.mcPlayersOnlineTotal.set(onlinePlayers);
+
+        double currentTps = calculateAverageTps(this.server.getTpsRecords(), TPS_WINDOW_SECONDS);
+        this.poseidonTps.set(currentTps);
+        this.mcTps.set(currentTps);
+    }
+
+    private double updateRecentTickAverage(long tickDurationNanos) {
+        this.recentTickDurationsNanos.addLast(tickDurationNanos);
+        this.recentTickDurationsTotalNanos += tickDurationNanos;
+
+        while (this.recentTickDurationsNanos.size() > this.recentTickWindowSize) {
+            Long removed = this.recentTickDurationsNanos.removeFirst();
+            this.recentTickDurationsTotalNanos -= removed.longValue();
+        }
+
+        if (this.recentTickDurationsNanos.isEmpty()) {
+            return 0D;
+        }
+
+        double averageNanos = this.recentTickDurationsTotalNanos / (double) this.recentTickDurationsNanos.size();
+        return averageNanos / 1_000_000.0D;
+    }
+
+    private double calculateAverageTps(LinkedList<Double> records, int maxSeconds) {
+        if (records == null || records.isEmpty()) {
+            return 20D;
+        }
+
+        int used = 0;
+        double sum = 0D;
+
+        synchronized (records) {
+            int maxRecords = Math.min(records.size(), maxSeconds);
+            for (int i = 0; i < maxRecords; i++) {
+                Double value = records.get(i);
+                if (value == null) {
+                    continue;
+                }
+                sum += value.doubleValue();
+                used++;
+            }
+        }
+
+        if (used == 0) {
+            return 20D;
+        }
+
+        return sum / used;
+    }
+}

--- a/src/main/java/net/minecraft/server/MinecraftServer.java
+++ b/src/main/java/net/minecraft/server/MinecraftServer.java
@@ -3,6 +3,7 @@ package net.minecraft.server;
 import com.legacyminecraft.poseidon.Poseidon;
 import com.legacyminecraft.poseidon.PoseidonConfig;
 import com.legacyminecraft.poseidon.PoseidonPlugin;
+import com.legacyminecraft.poseidon.monitoring.PrometheusMonitoringService;
 import com.legacyminecraft.poseidon.util.ServerLogRotator;
 import com.legacyminecraft.poseidon.utility.PerformanceStatistic;
 import com.legacyminecraft.poseidon.utility.PoseidonVersionChecker;
@@ -72,6 +73,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
 //    private WatchDogThread watchDogThread;
     private boolean modLoaderSupport = false;
 //    private PoseidonVersionChecker poseidonVersionChecker;
+    private PrometheusMonitoringService monitoringService;
     //Poseidon End
 
     public MinecraftServer(OptionSet options) { // CraftBukkit - adds argument OptionSet
@@ -159,6 +161,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
         }
 
         this.serverConfigurationManager = new ServerConfigurationManager(this);
+        this.monitoringService = PrometheusMonitoringService.startIfEnabled(this);
         // CraftBukkit - removed trackers
         long j = System.nanoTime();
         String s1 = this.propertyManager.getString("level-name", "world");
@@ -357,6 +360,9 @@ public class MinecraftServer implements Runnable, ICommandListener {
 
     public void stop() { // CraftBukkit - private -> public
         log.info("Stopping server");
+        if (this.monitoringService != null) {
+            this.monitoringService.stop();
+        }
 
         //Project Poseidon Start
 
@@ -540,6 +546,7 @@ public class MinecraftServer implements Runnable, ICommandListener {
     //Project Poseidon End - Tick Update
 
     private void h() {
+        long tickStartNanos = System.nanoTime();
         ArrayList arraylist = new ArrayList();
         Iterator iterator = trackerList.keySet().iterator();
 
@@ -628,6 +635,10 @@ public class MinecraftServer implements Runnable, ICommandListener {
             this.b();
         } catch (Exception exception) {
             log.log(Level.WARNING, "Unexpected exception while parsing console command", exception);
+        }
+
+        if (this.monitoringService != null) {
+            this.monitoringService.onTickComplete(System.nanoTime() - tickStartNanos);
         }
     }
 


### PR DESCRIPTION
# 📌 Pull Request

## Description

Small example of setting up Prometheus and Grafana monitoring for Poseidon.

Went a bit further and decided to setup the exporting directly by the server itself instead of using an exporter like JMX. Gives us a bit more control. This is setup using docker for local testing but can easily be extended to other deployment models


Details are available in `monitoring/README.md`

Sample included dasboard
<img width="3427" height="1124" alt="image" src="https://github.com/user-attachments/assets/7b0a0bcf-0807-4198-ad6e-39c9e994cbcc" />
