### PR TITLE
Ensure file loading order respects dependencies.

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/dependency/PluginDependency.java
+++ b/src/main/java/com/legacyminecraft/poseidon/dependency/PluginDependency.java
@@ -1,0 +1,68 @@
+package com.legacyminecraft.poseidon.dependency;
+
+import org.bukkit.plugin.InvalidDescriptionException;
+import org.bukkit.plugin.InvalidPluginException;
+import org.bukkit.plugin.PluginDescriptionFile;
+
+import java.io.*;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.jar.JarEntry;
+import java.util.jar.JarFile;
+import java.util.stream.Collectors;
+
+public final class PluginDependency {
+    private final File file;
+    private final String name;
+    private final List<String> depends;
+
+    private PluginDependency(File file, String name, List<String> depends) {
+        this.file = file;
+        this.name = name;
+        this.depends = depends;
+    }
+
+    public static PluginDependency of(File file) throws InvalidPluginException {
+        try (JarFile jar = new JarFile(file)) {
+            JarEntry entry = jar.getJarEntry("plugin.yml");
+
+            if (entry == null) {
+                throw new FileNotFoundException("Jar does not contain plugin.yml");
+            }
+
+            InputStream stream = jar.getInputStream(entry);
+            PluginDescriptionFile description = new PluginDescriptionFile(stream);
+
+            stream.close();
+
+            Object dependsRaw = description.getDepend();
+            List<?> dependsList = dependsRaw instanceof List
+                ? (ArrayList<?>) dependsRaw
+                : Collections.emptyList();
+            if (!dependsList.stream().allMatch(String.class::isInstance)) {
+                throw new InvalidObjectException("Plugin 'depends' is not a list of strings");
+            }
+
+            List<String> depends = dependsList.stream()
+                .map(String.class::cast)
+                .collect(Collectors.toList());
+
+            return new PluginDependency(file, description.getName(), depends);
+        } catch (IOException | InvalidDescriptionException exception) {
+            throw new InvalidPluginException(exception);
+        }
+    }
+
+    public File getFile() {
+        return file;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public List<String> getDepends() {
+        return depends;
+    }
+}

--- a/src/main/java/com/legacyminecraft/poseidon/dependency/PluginDependencyResolver.java
+++ b/src/main/java/com/legacyminecraft/poseidon/dependency/PluginDependencyResolver.java
@@ -1,0 +1,51 @@
+package com.legacyminecraft.poseidon.dependency;
+
+import org.bukkit.plugin.InvalidPluginException;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+public final class PluginDependencyResolver {
+    public static List<PluginDependency> resolve(List<PluginDependency> items) throws InvalidPluginException {
+        Map<String, PluginDependency> byName = items.stream()
+            .collect(Collectors.toMap(PluginDependency::getName, i -> i));
+
+        List<PluginDependency> result = new ArrayList<>();
+        Set<String> checked = new HashSet<>();
+        Set<String> checking = new HashSet<>();
+
+        for (PluginDependency item : items) {
+            check(item, byName, checked, checking, result);
+        }
+
+        return result;
+    }
+
+    private static void check(
+        PluginDependency item,
+        Map<String, PluginDependency> byName,
+        Set<String> checked,
+        Set<String> checking,
+        List<PluginDependency> result
+    ) throws InvalidPluginException {
+        String name = item.getName();
+
+        if (checked.contains(name)) return;
+        if (!checking.add(name)) throwIllegalState("Circular dependency involving '" + name + "'.");
+
+        for (String dependencyName : item.getDepends()) {
+            PluginDependency dependency = byName.get(dependencyName);
+            if (dependency == null) throwIllegalState("Missing dependency '" + dependencyName + "' for item '" + name + "'.");
+
+            check(dependency, byName, checked, checking, result);
+        }
+
+        checking.remove(name);
+        checked.add(name);
+        result.add(item);
+    }
+
+    private static void throwIllegalState(String message) throws InvalidPluginException {
+        throw new InvalidPluginException(new IllegalStateException(message));
+    }
+}

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -3,6 +3,8 @@ package org.bukkit.plugin;
 import com.google.common.collect.ImmutableSet;
 import com.google.common.collect.MapMaker;
 import com.legacyminecraft.poseidon.Poseidon;
+import com.legacyminecraft.poseidon.dependency.PluginDependency;
+import com.legacyminecraft.poseidon.dependency.PluginDependencyResolver;
 import com.legacyminecraft.poseidon.event.PoseidonCustomListener;
 import com.legacyminecraft.poseidon.utility.PerformanceStatistic;
 import org.bukkit.Server;
@@ -23,6 +25,7 @@ import java.util.*;
 import java.util.logging.Level;
 import java.util.regex.Matcher;
 import java.util.regex.Pattern;
+import java.util.stream.Collectors;
 
 /**
  * Handles all plugin management from the Server
@@ -150,7 +153,43 @@ public final class SimplePluginManager implements PluginManager {
         boolean allFailed = false;
         boolean finalPass = false;
 
-        LinkedList<File> filesList = new LinkedList(Arrays.asList(files));
+//        LinkedList<File> filesList = new LinkedList(Arrays.asList(files));
+        // Poseidon start
+        if (files == null || files.length == 0) {
+            return new Plugin[0];
+        }
+
+        LinkedList<File> filesList;
+        LinkedList<File> unresolvedFilesList = new LinkedList<>(Arrays.asList(files));
+        Collections.sort(unresolvedFilesList);
+
+        try {
+            List<PluginDependency> resolvedFilenames = PluginDependencyResolver.resolve(
+                unresolvedFilesList
+                    .stream()
+                    .map(file -> {
+                        try {
+                            return PluginDependency.of(file);
+                        } catch (InvalidPluginException ex) {
+                            server.getLogger().log(Level.SEVERE, "Could not check dependency of '" + file.getPath() + "' in folder '" + directory.getPath() + "': ", ex.getCause());
+                        }
+
+                        return null;
+                    })
+                    .filter(Objects::nonNull)
+                    .collect(Collectors.toList())
+            );
+
+            filesList = resolvedFilenames
+                .stream()
+                .map(PluginDependency::getFile)
+                .collect(Collectors.toCollection(LinkedList::new));
+        } catch (InvalidPluginException ex) {
+            server.getLogger().log(Level.SEVERE, "Could not check plugin dependencies in folder '" + directory.getPath() + "': ", ex.getCause());
+
+            return new Plugin[0];
+        }
+        // Poseidon end
 
         if (!(server.getUpdateFolder().equals(""))) {
             updateDirectory = new File(directory, server.getUpdateFolder());

--- a/src/main/java/org/bukkit/plugin/SimplePluginManager.java
+++ b/src/main/java/org/bukkit/plugin/SimplePluginManager.java
@@ -167,6 +167,19 @@ public final class SimplePluginManager implements PluginManager {
             List<PluginDependency> resolvedFilenames = PluginDependencyResolver.resolve(
                 unresolvedFilesList
                     .stream()
+                    .filter(file -> {
+                        if (file.isDirectory()) return false;
+
+                        for (Pattern filter: fileAssociations.keySet()) {
+                            Matcher match = filter.matcher(file.getName());
+
+                            if (match.find()) {
+                                return true;
+                            }
+                        }
+
+                        return false;
+                    })
                     .map(file -> {
                         try {
                             return PluginDependency.of(file);


### PR DESCRIPTION
# 📌 Pull Request

## Description

This PR implements a proper plugin loading order to respect dependencies.

```
A ABC B C D E F G H

B depends on D
C depends on D
D depends on A
H depends on B
ABC depends on A, B, C
```

## Motivation & Context

A proper standalone Kotlin plugin is impossible without this feature.

## Type of Change

Please tick all that apply:

- [X] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ⚡ Performance improvement
- [ ] 🧩 New feature (non-breaking)
- [ ] 🔧 Refactor / cleanup (no functional changes)
- [ ] 🔥 Crash / exploit fix
- [ ] 📚 Documentation update
- [ ] ❗ Breaking change (may affect plugins or server behavior)

## Testing Performed

Debugged right into `SimplePluginManager::loadPlugins():194`, checked the order, was happy with the results.

- [X] Compiled successfully with `mvn clean package`
- [X] Tested on a Beta 1.7.3 server
- [X] Existing functionality verified
- [X] Edge cases considered

## Logs / Screenshots (if applicable)

<img width="716" height="299" alt="image" src="https://github.com/user-attachments/assets/8a7ee6bc-0e0f-4679-9032-b567cdaa8b21" />

[dummy_jars.zip](https://github.com/user-attachments/files/26509140/dummy_jars.zip)

## Checklist

Please confirm the following:
- [X] No unnecessary formatting or whitespace-only changes
- [X] Changes are compatible with Minecraft Beta 1.7.3
- [X] No dependencies have been added without discussion with the RetroMC team


## Thanks for contributing to Project Poseidon!
