### PR TITLE
Fix incorrect block updates for doors

### DIFF
--- a/src/main/java/net/minecraft/server/BlockDoor.java
+++ b/src/main/java/net/minecraft/server/BlockDoor.java
@@ -146,9 +146,8 @@ public class BlockDoor extends Block {
             boolean flag = false;
 
             if (world.getTypeId(i, j + 1, k) != this.id) {
-                // Poseidon start
-                return;
-                // Poseidon end
+                world.setTypeId(i, j, k, 0);
+                flag = true;
             }
 
             if (!world.e(i, j - 1, k)) {
@@ -160,9 +159,7 @@ public class BlockDoor extends Block {
             }
 
             if (flag) {
-                // Poseidon start
-                if (!world.isStatic && (i1 & 8) == 0) {
-                // Poseidon end
+                if (!world.isStatic) {
                     this.g(world, i, j, k, i1);
                 }
             } else if (l > 0 && Block.byId[l].isPowerSource()) {

--- a/src/main/java/net/minecraft/server/ItemDoor.java
+++ b/src/main/java/net/minecraft/server/ItemDoor.java
@@ -20,8 +20,6 @@ public class ItemDoor extends Item {
         if (l != 1) {
             return false;
         } else {
-            int clickedX = i, clickedY = j, clickedZ = k; // CraftBukkit
-
             ++j;
             Block block;
 
@@ -72,26 +70,22 @@ public class ItemDoor extends Item {
                 }
 
                 CraftBlockState blockState = CraftBlockState.getBlockState(world, i, j, k); // CraftBukkit
-
                 world.suppressPhysics = true;
                 world.setTypeIdAndData(i, j, k, block.id, i1);
 
-                // CraftBukkit start - bed
-                world.suppressPhysics = false;
-                world.applyPhysics(i, j, k, Block.REDSTONE_WIRE.id);
-                BlockPlaceEvent event = CraftEventFactory.callBlockPlaceEvent(world, entityhuman, blockState, clickedX, clickedY, clickedZ, block);
+                // CraftBukkit start
+                BlockPlaceEvent event = CraftEventFactory.callBlockPlaceEvent(world, entityhuman, blockState, i, j, k, block);
 
                 if (event.isCancelled() || !event.canBuild()) {
                     event.getBlockPlaced().setTypeIdAndData(blockState.getTypeId(), blockState.getRawData(), false);
                     return false;
                 }
-
-                world.suppressPhysics = true;
                 // CraftBukkit end
+
                 world.setTypeIdAndData(i, j + 1, k, block.id, i1 + 8);
                 world.suppressPhysics = false;
-                // world.applyPhysics(i, j, k, block.id); // CraftBukkit - moved up
-                world.applyPhysics(i, j + 1, k, Block.REDSTONE_WIRE.id);
+                world.applyPhysics(i, j, k, block.id);
+                world.applyPhysics(i, j + 1, k, block.id);
                 --itemstack.count;
                 return true;
             }


### PR DESCRIPTION
# 📌 Pull Request

## Description

Correctly fixes the issue described in #184 where placing a door next to an opened trap door would cause the bottom half of the door to be broken and a door item to be dropped on the floor. When powering the remaining upper half of the door with a redstone torch, the torch would be removed and another door item would be dropped.

The actual cause of this issue is a CraftBukkit change in ItemDoor.java which sends a block update from the perspective of a redstone wire, in order to instantly trigger redstone updates for the door. This behavior was later reverted in CraftBukkit.

<!--
Provide a clear and concise summary of what this PR does.
Explain *why* the change is needed and what problem it solves.
-->

## Related Issues / Discussions

<!--
Link any related issues, PRs, or discussions.
Use "Fixes #123" to automatically close issues when merged.
-->

- Related to #184

## Motivation and Context

#184 introduced a bug where if a door is broken at the top half, the bottom half is not removed, allowing for half-door blocks to be created.

## Type of Change

Please tick all that apply:

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ⚡ Performance improvement
- [ ] 🧩 New feature (non-breaking)
- [ ] 🔧 Refactor / cleanup (no functional changes)
- [ ] 🔥 Crash / exploit fix
- [ ] 📚 Documentation update
- [ ] ❗ Breaking change (may affect plugins or server behavior)

## Testing Performed

<!--
Describe how this change was tested.
Include environments, steps, and results.
-->

- [x] Compiled successfully with `mvn clean package`
- [x] Tested on a Beta 1.7.3 server
- [x] Existing functionality verified
- [x] Edge cases considered

**Test details:**
```text
Tested on local server, verified the duplication glitch to be fixed and the correct removal of the entire door block to take place when breaking it at the top half and bottom half.
```

## Compatibility Considerations

<!-- Does this change affect: Plugins? Network behavior? UUID / inventory handling? Other? -->

- [x] No known compatibility impact
- [ ] Potential plugin impact (described below)
- [ ] Network / protocol (Netcode) behavior changed
- [ ] Configuration change required

## Checklist

Please confirm the following:
- [x] No unnecessary formatting or whitespace-only changes
- [x] Changes are compatible with Minecraft Beta 1.7.3
- [x] No dependencies have been added without discussion with the RetroMC team
