### PR TITLE
The BlockDiode now correctly activates the BlockNote

### DIFF
--- a/src/main/java/net/minecraft/server/BlockDiode.java
+++ b/src/main/java/net/minecraft/server/BlockDiode.java
@@ -112,7 +112,10 @@ public class BlockDiode extends Block {
     }
 
     public boolean isPowerSource() {
-        return false;
+        // Project Poseidon start - Fix for BlockNote activation
+        //return false;
+        return this.c;
+        // Project Poseidon end
     }
 
     public void postPlace(World world, int i, int j, int k, EntityLiving entityliving) {


### PR DESCRIPTION
# 📌 Pull Request

## Description

That PR resolves an issue with BlockDiode (Repeater block) not behaving correctly when interacting with BlockNote (Note block)

## Related Issues / Discussions

https://discord.com/channels/654195300478746625/688899501162758170/1500880647210795059

## Motivation & Context

Bug fix

## Type of Change

Please tick all that apply:

- [x] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ⚡ Performance improvement
- [ ] 🧩 New feature (non-breaking)
- [ ] 🔧 Refactor / cleanup (no functional changes)
- [ ] 🔥 Crash / exploit fix
- [ ] 📚 Documentation update
- [ ] ❗ Breaking change (may affect plugins or server behavior)

## Testing Performed

<!--
Describe how this change was tested.
Include environments, steps, and results.
-->

- [x] Compiled successfully with `mvn clean package`
- [x] Tested on a Beta 1.7.3 server
- [x] Existing functionality verified
- [x] Edge cases considered

**Test details:**
https://discord.com/channels/654195300478746625/688899501162758170/1504122185831420005
0:00 - 0:06 - behavior w/o the patch , 0:06 - 0:11 - behavior with the patch

Also, several tests with the directions of activation did not reveal any negative changes.

## Logs / Screenshots (if applicable)
N/A
<!-- Paste relevant log output, stack traces, or attach screenshots to help reviewers understand the change. -->

## Compatibility Considerations

- [x] No known compatibility impact
- [ ] Potential plugin impact (described below)
- [ ] Network / protocol (Netcode) behavior changed
- [ ] Configuration change required


## Compatibility Notes

This change may cause an increased number of the BlockRedstoneEvents.


## Checklist

Please confirm the following:
- [x] No unnecessary formatting or whitespace-only changes
- [x] Changes are compatible with Minecraft Beta 1.7.3
- [x] No dependencies have been added without discussion with the RetroMC team

