### PR TITLE
Add weather disable

### DIFF
--- a/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
+++ b/src/main/java/com/legacyminecraft/poseidon/PoseidonConfig.java
@@ -180,6 +180,9 @@ public class PoseidonConfig extends Configuration {
                 "This setting controls the maximum number of entities of a mob spawner type that can exist within the defined chunk radius around a mob spawner. If the number of entities exceeds this limit, the spawner will stop spawning additional entities of that type. This is useful to stop the extreme lag that can be caused by mob spawners.");
 
 
+        generateConfigOption("world.settings.disable-natural-weather-change.enabled", false);
+        generateConfigOption("world.settings.disable-natural-weather-change.info", "When enabled, weather will no longer change naturally over time. Weather can still be changed by plugins and commands.");
+
         //generateConfigOption("world-settings.eject-from-vehicle-on-teleport.enabled", true);
         //generateConfigOption("world-settings.eject-from-vehicle-on-teleport.info", "Eject the player from a boat or minecart before teleporting them preventing cross world coordinate exploits.");
 

--- a/src/main/java/net/minecraft/server/World.java
+++ b/src/main/java/net/minecraft/server/World.java
@@ -1,5 +1,6 @@
 package net.minecraft.server;
 
+import com.legacyminecraft.poseidon.PoseidonConfig;
 import org.bukkit.Bukkit;
 import org.bukkit.Location;
 import org.bukkit.block.BlockState;
@@ -1772,6 +1773,7 @@ public class World implements IBlockAccess {
                 --this.m;
             }
 
+            if (!PoseidonConfig.getInstance().getConfigBoolean("world.settings.disable-natural-weather-change.enabled", false)) {
             int i = this.worldData.getThunderDuration();
 
             if (i <= 0) {
@@ -1815,6 +1817,7 @@ public class World implements IBlockAccess {
                     }
                     // CraftBukkit end
                 }
+            }
             }
 
             this.i = this.j;


### PR DESCRIPTION
# 📌 Pull Request

## Description

Adds a weather disable to poseidon config (default false) that stops all weather from occuring unless changed by a plugin

## Motivation & Context

Minor annoyance when recording footage.

## Type of Change

Please tick all that apply:

- [ ] 🐛 Bug fix (non-breaking change that fixes an issue)
- [ ] ⚡ Performance improvement
- [x] 🧩 New feature (non-breaking)
- [ ] 🔧 Refactor / cleanup (no functional changes)
- [ ] 🔥 Crash / exploit fix
- [ ] 📚 Documentation update
- [ ] ❗ Breaking change (may affect plugins or server behavior)

## Testing Performed

<!--
Describe how this change was tested.
Include environments, steps, and results.
-->

- [x] Compiled successfully with `mvn clean package`
- [x] Tested on a Beta 1.7.3 server

**Test details:**
```text
Local server, sat in the server recording footage for 25 mins
```

## Compatibility Considerations

<!-- Does this change affect: Plugins? Network behavior? UUID / inventory handling? Other? -->

- [x] No known compatibility impact
- [ ] Potential plugin impact (described below)
- [ ] Network / protocol (Netcode) behavior changed
- [ ] Configuration change required


## Compatibility Notes

<!-- Describe any known compatibility risks or required changes if applicable. -->

## Checklist

Please confirm the following:
- [x] No unnecessary formatting or whitespace-only changes
- [x] Changes are compatible with Minecraft Beta 1.7.3
- [x] No dependencies have been added without discussion with the RetroMC team

## Additional Notes
<!-- Anything else reviewers should know? Design decisions, limitations, future follow-ups, etc. -->



## Thanks for contributing to Project Poseidon!
